### PR TITLE
Mark visionOS unavailable for `Bindable`

### DIFF
--- a/Sources/Perception/Bindable.swift
+++ b/Sources/Perception/Bindable.swift
@@ -9,6 +9,7 @@
   @available(macOS, introduced: 10.15, obsoleted: 14)
   @available(tvOS, introduced: 13, obsoleted: 17)
   @available(watchOS, introduced: 6, obsoleted: 10)
+  @available(visionOS, unavailable)
   @dynamicMemberLookup
   @propertyWrapper
   public struct Bindable<Value> {


### PR DESCRIPTION
For some reason, when building the project for visionOS, `Bindable` isn't properly gated from compiling, but attempting to reference itself fails. 

In order to get `swift-perception` running on visionOS, we need to mark `Bindable` as `@available(visionOS, unavailable)`.

Since targeting visionOS is equivalent to targeting iOS 17+, I don't see a reason this shadowed type should ever need to be exposed on visionOS.

![CleanShot 2024-01-11 at 15 10 06@2x](https://github.com/pointfreeco/swift-perception/assets/7174994/8d2e5f7e-b7b4-4e88-b2e6-5f38b04266e3)