### PR TITLE
Perception checking in iOS 17 and a bug fix

### DIFF
--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -24,6 +24,15 @@ struct ContentView: View {
     WithPerceptionTracking {
       let _ = print("\(Self.self): tracked change.")
       Form {
+        List {
+          ForEach(Array(1...10), id: \.self) {
+            Text("\($0)")
+          }
+          .onDelete { _ in
+            //_ = model.count
+          }
+        }
+
         if model.isDisplayingCount {
           Text(model.count.description)
         } else {

--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -24,15 +24,6 @@ struct ContentView: View {
     WithPerceptionTracking {
       let _ = print("\(Self.self): tracked change.")
       Form {
-        List {
-          ForEach(Array(1...10), id: \.self) {
-            Text("\($0)")
-          }
-          .onDelete { _ in
-            //_ = model.count
-          }
-        }
-
         if model.isDisplayingCount {
           Text(model.count.description)
         } else {

--- a/Sources/Perception/PerceptionRegistrar.swift
+++ b/Sources/Perception/PerceptionRegistrar.swift
@@ -229,7 +229,9 @@ extension PerceptionRegistrar: Hashable {
   extension String {
     fileprivate var isActionClosure: Bool {
       var view = self[...].utf8
-      guard view.starts(with: "closure #".utf8) else { return false }
+      guard 
+        view.starts(with: "closure #".utf8) || view.starts(with: "implicit closure #".utf8)
+      else { return false }
       view = view.drop(while: { $0 != .init(ascii: "-") })
       return view.starts(with: "-> () in ".utf8)
     }

--- a/Sources/Perception/PerceptionRegistrar.swift
+++ b/Sources/Perception/PerceptionRegistrar.swift
@@ -214,10 +214,9 @@ extension PerceptionRegistrar: Hashable {
       let mangledSymbol = callStackSymbol.utf8
         .drop(while: { $0 != .init(ascii: "$") })
         .prefix(while: { $0 != .init(ascii: " ") })
-      let mangledSymbolString = String(Substring(mangledSymbol))
       guard
         mangledSymbol.isMangledViewBodyGetter,
-        let demangled = mangledSymbolString.demangled,
+        let demangled = String(Substring(mangledSymbol)).demangled,
         !demangled.isActionClosure
       else {
         continue

--- a/Sources/Perception/PerceptionRegistrar.swift
+++ b/Sources/Perception/PerceptionRegistrar.swift
@@ -80,6 +80,8 @@ extension PerceptionRegistrar {
     _ subject: Subject,
     keyPath: KeyPath<Subject, Member>
   ) {
+    perceptionCheck()
+    
     #if canImport(Observation)
       if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
         func `open`<T: Observable>(_ subject: T) {
@@ -92,7 +94,6 @@ extension PerceptionRegistrar {
           open(subject)
         }
       } else {
-        perceptionCheck()
         self.perceptionRegistrar.access(subject, keyPath: keyPath)
       }
     #endif
@@ -194,7 +195,7 @@ extension PerceptionRegistrar: Hashable {
 
 #if DEBUG
   private func perceptionCheck() {
-    if #unavailable(iOS 17, macOS 14, tvOS 17, watchOS 10),
+    if
       !_PerceptionLocals.isInPerceptionTracking,
       !_PerceptionLocals.skipPerceptionChecking,
       isInSwiftUIBody()

--- a/Sources/Perception/WithPerceptionTracking.swift
+++ b/Sources/Perception/WithPerceptionTracking.swift
@@ -63,6 +63,8 @@ public struct WithPerceptionTracking<Content> {
     }
   }
 
+  @_transparent
+  @inline(__always)
   private func instrumentedBody() -> Content {
     #if DEBUG
       return _PerceptionLocals.$isInPerceptionTracking.withValue(true) {

--- a/Sources/Perception/WithPerceptionTracking.swift
+++ b/Sources/Perception/WithPerceptionTracking.swift
@@ -54,7 +54,7 @@ public enum _PerceptionLocals {
 @MainActor
 public struct WithPerceptionTracking<Content> {
   @State var id = 0
-  private let content: () -> Content
+  let content: () -> Content
 
   public var body: Content {
     if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {

--- a/Sources/Perception/WithPerceptionTracking.swift
+++ b/Sources/Perception/WithPerceptionTracking.swift
@@ -1,14 +1,5 @@
 import SwiftUI
 
-@available(iOS, deprecated: 17)
-@available(macOS, deprecated: 14)
-@available(tvOS, deprecated: 17)
-@available(watchOS, deprecated: 10)
-public enum _PerceptionLocals {
-  @TaskLocal public static var isInPerceptionTracking = false
-  @TaskLocal public static var skipPerceptionChecking = false
-}
-
 /// Observes changes to perceptible models.
 ///
 /// Use this view to automatically subscribe to the changes of any fields in ``Perceptible()``
@@ -58,16 +49,12 @@ public struct WithPerceptionTracking<Content> {
 
   public var body: Content {
     if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
-      return _PerceptionLocals.$isInPerceptionTracking.withValue(true) {
-        self.instrumentedBody()
-      }
+      return self.instrumentedBody()
     } else {
       // NB: View will not re-render when 'id' changes unless we access it in the view.
       let _ = self.id
       return withPerceptionTracking {
-        _PerceptionLocals.$isInPerceptionTracking.withValue(true) {
-          self.instrumentedBody()
-        }
+        self.instrumentedBody()
       } onChange: {
         Task { @MainActor in
           self.id += 1
@@ -168,4 +155,13 @@ extension WithPerceptionTracking: View where Content: View {
   public init(@ViewBuilder content: @escaping () -> Content) {
     self.content = content
   }
+}
+
+@available(iOS, deprecated: 17)
+@available(macOS, deprecated: 14)
+@available(tvOS, deprecated: 17)
+@available(watchOS, deprecated: 10)
+public enum _PerceptionLocals {
+  @TaskLocal public static var isInPerceptionTracking = false
+  @TaskLocal public static var skipPerceptionChecking = false
 }

--- a/Sources/Perception/WithPerceptionTracking.swift
+++ b/Sources/Perception/WithPerceptionTracking.swift
@@ -54,13 +54,15 @@ public enum _PerceptionLocals {
 @MainActor
 public struct WithPerceptionTracking<Content: View>: View {
   @State var id = 0
-  let content: () -> Content
+  let _content: () -> Content
   public init(@ViewBuilder content: @escaping () -> Content) {
-    self.content = content
+    self._content = content
   }
   public var body: Content {
     if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
-      return self.content()
+      return _PerceptionLocals.$isInPerceptionTracking.withValue(true) {
+        self.content()
+      }
     } else {
       // NB: View will not re-render when 'id' changes unless we access it in the view.
       let _ = self.id
@@ -74,5 +76,15 @@ public struct WithPerceptionTracking<Content: View>: View {
         }
       }
     }
+  }
+
+  private func content() -> Content {
+    #if DEBUG
+      return _PerceptionLocals.$isInPerceptionTracking.withValue(true) {
+        self._content()
+      }
+    #else
+      return self._content()
+    #endif
   }
 }

--- a/Tests/PerceptionTests/RuntimeWarningTests.swift
+++ b/Tests/PerceptionTests/RuntimeWarningTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import Perception
 import SwiftUI
 import XCTest
@@ -262,6 +263,66 @@ final class RuntimeWarningTests: XCTestCase {
       var body: some View {
         Text("Hi")
           .onAppear { _ = self.model.count }
+      }
+    }
+
+    self.render(FeatureView())
+  }
+
+  func testActionClosure_CallMethodWithArguments() {
+    struct FeatureView: View {
+      @State var model = Model()
+      var body: some View {
+        Text("Hi")
+          .onAppear { _ = foo(42) }
+      }
+      func foo(_: Int) -> Bool {
+        _ = self.model.count
+        return true
+      }
+    }
+
+    self.render(FeatureView())
+  }
+
+  func testActionClosure_WithArguments() {
+    struct FeatureView: View {
+      @State var model = Model()
+      var body: some View {
+        Text("Hi")
+          .onReceive(Just(1)) { _ in
+            _ = self.model.count
+          }
+      }
+    }
+
+    self.render(FeatureView())
+  }
+
+  func testActionClosure_WithArguments_ImplicitClosure() {
+    struct FeatureView: View {
+      @State var model = Model()
+      var body: some View {
+        Text("Hi")
+          .onReceive(Just(1), perform: self.foo)
+      }
+      func foo(_: Int) {
+        _ = self.model.count
+      }
+    }
+
+    self.render(FeatureView())
+  }
+
+  func testImplicitActionClosure() {
+    struct FeatureView: View {
+      @State var model = Model()
+      var body: some View {
+        Text("Hi")
+          .onAppear(perform: foo)
+      }
+      func foo() {
+        _ = self.model.count
       }
     }
 

--- a/Tests/PerceptionTests/RuntimeWarningTests.swift
+++ b/Tests/PerceptionTests/RuntimeWarningTests.swift
@@ -269,13 +269,11 @@ final class RuntimeWarningTests: XCTestCase {
   }
 
   private func expectFailure() {
-    if #unavailable(iOS 17, macOS 14, tvOS 17, watchOS 10) {
-      XCTExpectFailure {
-        $0.compactDescription == """
-          Perceptible state was accessed but is not being tracked. Track changes to state by \
-          wrapping your view in a 'WithPerceptionTracking' view.
-          """
-      }
+    XCTExpectFailure {
+      $0.compactDescription == """
+        Perceptible state was accessed but is not being tracked. Track changes to state by \
+        wrapping your view in a 'WithPerceptionTracking' view.
+        """
     }
   }
 


### PR DESCRIPTION
This PR primarily adds perception checking even for iOS 17. We originally omitted perception checking in iOS 17 because the library will delegate down to Swift's native observation tools, and so technically `WithPerceptionTracking` isn't necessary. But of course you may be deploying for iOS 16 and testing on iOS 17, and so you probably want to know if you leave off the wrapper view.

I have also fixed #9. We have specific logic in `isInSwiftUIBody` for checking if state is being accessed from a SwiftUI action closure (such as `onDelete { … }`), but that logic doesn't work when passing a method directly (i.e. `onDelete(perform: delete)`). The fix is easy enough.