### PR TITLE
Update `.spi.yml`

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,7 +1,5 @@
 version: 1
 builder:
   configs:
-  - documentation_targets:
-    - Perception
-    - PerceptionMacros
-    swift_version: 5.9
+  - documentation_targets: [Perception]
+    swift_version: 5.8


### PR DESCRIPTION
  - I don't think we want to publish docs for the internal macro code.
  - I think we should try building on Swift 5.8 to see if the APIs stop showing up as "deprecated" by default.