### PR TITLE
Make perception checks configurable

### DIFF
--- a/Sources/Perception/PerceptionChecking.swift
+++ b/Sources/Perception/PerceptionChecking.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public var isPerceptionCheckingEnabled: Bool {
+  get { perceptionChecking.isPerceptionCheckingEnabled }
+  set { perceptionChecking.isPerceptionCheckingEnabled = newValue }
+}
+
+private let perceptionChecking = PerceptionChecking()
+
+private class PerceptionChecking: @unchecked Sendable {
+  var isPerceptionCheckingEnabled: Bool {
+    get {
+      lock.lock()
+      defer { lock.unlock() }
+      return _isPerceptionCheckingEnabled
+    }
+    set {
+      lock.lock()
+      defer { lock.unlock() }
+      _isPerceptionCheckingEnabled = newValue
+    }
+  }
+  let lock = NSLock()
+  #if DEBUG
+    var _isPerceptionCheckingEnabled = true
+  #else
+    var _isPerceptionCheckingEnabled = false
+  #endif
+}

--- a/Sources/Perception/PerceptionRegistrar.swift
+++ b/Sources/Perception/PerceptionRegistrar.swift
@@ -196,6 +196,7 @@ extension PerceptionRegistrar: Hashable {
 #if DEBUG
   private func perceptionCheck() {
     if
+      isPerceptionCheckingEnabled,
       !_PerceptionLocals.isInPerceptionTracking,
       !_PerceptionLocals.skipPerceptionChecking,
       isInSwiftUIBody()

--- a/Sources/Perception/WithPerceptionTracking.swift
+++ b/Sources/Perception/WithPerceptionTracking.swift
@@ -118,11 +118,11 @@ extension WithPerceptionTracking: TableColumnContent where Content: TableColumnC
     self.content = content
   }
 
-  public var tableColumnBody: Never {
+  nonisolated public var tableColumnBody: Never {
     fatalError()
   }
 
-  public static func _makeContent(
+  nonisolated public static func _makeContent(
     content: _GraphValue<WithPerceptionTracking<Content>>, inputs: _TableColumnInputs
   ) -> _TableColumnOutputs {
     Content._makeContent(content: content[\.body], inputs: inputs)
@@ -141,7 +141,7 @@ extension WithPerceptionTracking: TableRowContent where Content: TableRowContent
     self.content = content
   }
 
-  public var tableRowBody: Never {
+  nonisolated public var tableRowBody: Never {
     fatalError()
   }
 }


### PR DESCRIPTION
Perception checking can be expensive, so let's give folks to the option to toggle it off when developing.