### PR TITLE
`@Perceptible` Macro supports properties with the `package` access modifier

### DIFF
--- a/Sources/PerceptionMacros/PerceptibleMacro.swift
+++ b/Sources/PerceptionMacros/PerceptibleMacro.swift
@@ -128,7 +128,7 @@ extension DeclModifierListSyntax {
         switch $0.name.tokenKind {
         case .keyword(let keyword):
           switch keyword {
-          case .fileprivate, .private, .internal, .public:
+          case .fileprivate, .private, .internal, .package, .public:
             return false
           default:
             return true


### PR DESCRIPTION
I want to change the `@Perceptible` Macro so that properties with the `package` access modifier do not cause build errors.

## See Also
- https://github.com/apple/swift/issues/71060
- https://github.com/apple/swift/pull/71061

## Problem Reproduction

### ✅ OK

```swift
import Observation
import Perception

@Perceptible
class MyObservable1 {
    var value = 0
}
```

### ❌ Build failed

```swift
import Observation
import Perception

@Perceptible
class MyObservable2 {
    package var value = 0
}
```

![スクリーンショット 2024-02-05 5 02 07](https://github.com/pointfreeco/swift-perception/assets/13805382/51cf2635-f3e8-4d8a-90a6-6e4fd12cff76)

```sh
% swift build

Fetching https://github.com/apple/swift-syntax from cache
Fetching https://github.com/apple/swift-collections from cache
Fetching https://github.com/pointfreeco/swift-perception from cache
Fetched https://github.com/pointfreeco/swift-perception (1.17s)
Fetching https://github.com/pointfreeco/xctest-dynamic-overlay from cache
Computing version for https://github.com/pointfreeco/swift-perception
Fetched https://github.com/pointfreeco/xctest-dynamic-overlay (0.53s)
Computed https://github.com/pointfreeco/swift-perception at 1.1.1 (0.89s)
Fetched https://github.com/apple/swift-syntax (2.10s)
Fetched https://github.com/apple/swift-collections (2.12s)
Computing version for https://github.com/pointfreeco/xctest-dynamic-overlay
Computed https://github.com/pointfreeco/xctest-dynamic-overlay at 1.1.0 (0.60s)
Computing version for https://github.com/apple/swift-collections
Computed https://github.com/apple/swift-collections at 1.0.6 (0.54s)
Computing version for https://github.com/apple/swift-syntax
Computed https://github.com/apple/swift-syntax at 509.1.1 (0.55s)
Creating working copy for https://github.com/apple/swift-collections
Working copy of https://github.com/apple/swift-collections resolved at 1.0.6
Creating working copy for https://github.com/pointfreeco/swift-perception
Working copy of https://github.com/pointfreeco/swift-perception resolved at 1.1.1
Creating working copy for https://github.com/pointfreeco/xctest-dynamic-overlay
Working copy of https://github.com/pointfreeco/xctest-dynamic-overlay resolved at 1.1.0
Creating working copy for https://github.com/apple/swift-syntax
Working copy of https://github.com/apple/swift-syntax resolved at 509.1.1
Building for debugging...
error: emit-module command failed with exit code 1 (use -v to see invocation)
/var/folders/78/4hltfk2n2fz2f88371bhlp_h0000gn/T/swift-generated-sources/@__swiftmacro_10Playground13MyObservable2C5value17PerceptionTrackedfMp_.swift:2:5: error: duplicate modifier
    package  var _value  = 0
    ^~~~~~~
/Users/treastrain/Desktop/Playground/Sources/main.swift:6:17: note: in expansion of macro 'PerceptionTracked' here
    package var value = 0
                ^~~~~
/var/folders/78/4hltfk2n2fz2f88371bhlp_h0000gn/T/swift-generated-sources/@__swiftmacro_10Playground13MyObservable2C5value17PerceptionTrackedfMp_.swift:1:20: note: modifier already specified here
@PerceptionIgnored private
                   ^~~~~~~
/Users/treastrain/Desktop/Playground/Sources/main.swift:6:17: note: in expansion of macro 'PerceptionTracked' here
    package var value = 0
                ^~~~~
/var/folders/78/4hltfk2n2fz2f88371bhlp_h0000gn/T/swift-generated-sources/@__swiftmacro_10Playground13MyObservable2C5value17PerceptionTrackedfMp_.swift:2:5: error: duplicate modifier
    package  var _value  = 0
    ^~~~~~~
/Users/treastrain/Desktop/Playground/Sources/main.swift:6:17: note: in expansion of macro 'PerceptionTracked' here
    package var value = 0
                ^~~~~
/var/folders/78/4hltfk2n2fz2f88371bhlp_h0000gn/T/swift-generated-sources/@__swiftmacro_10Playground13MyObservable2C5value17PerceptionTrackedfMp_.swift:1:20: note: modifier already specified here
@PerceptionIgnored private
                   ^~~~~~~
/Users/treastrain/Desktop/Playground/Sources/main.swift:6:17: note: in expansion of macro 'PerceptionTracked' here
    package var value = 0
                ^~~~~
error: fatalError
```

## Environment
- Perception 1.1.1 and `main`

```sh
% swiftc -version

swift-driver version: 1.87.3 Apple Swift version 5.9.2 (swiftlang-5.9.2.2.56 clang-1500.1.0.2.5)
Target: arm64-apple-macosx14.0
```

## Additional Information
Thanks to @p-x9 via https://x.com/p_x9/status/1749482697813320096 (Japanese)