### PR TITLE
Fix perception check in iOS 15.

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -348,7 +348,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -405,7 +405,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -430,7 +430,6 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -459,7 +458,6 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -41,14 +41,24 @@ struct ContentView: View {
         }
       }
       .sheet(isPresented: $model.isPresentingSheet) {
-        WithPerceptionTracking {
-          Form {
-            Text(model.count.description)
-            Button("Decrement") { model.decrementButtonTapped() }
-            Button("Increment") { model.incrementButtonTapped() }
+        if #available(iOS 16.0, *) {
+          WithPerceptionTracking {
+            Form {
+              Text(model.count.description)
+              Button("Decrement") { model.decrementButtonTapped() }
+              Button("Increment") { model.incrementButtonTapped() }
+            }
+            .presentationDetents([.medium])
+          }
+        } else {
+          WithPerceptionTracking {
+            Form {
+              Text(model.count.description)
+              Button("Decrement") { model.decrementButtonTapped() }
+              Button("Increment") { model.incrementButtonTapped() }
+            }
           }
         }
-        .presentationDetents([.medium])
       }
     }
   }

--- a/Sources/Perception/PerceptionRegistrar.swift
+++ b/Sources/Perception/PerceptionRegistrar.swift
@@ -269,7 +269,7 @@ extension PerceptionRegistrar: Hashable {
     fileprivate var isActionClosure: Bool {
       var view = self[...].utf8
       view = view.drop(while: { $0 != .init(ascii: "#") })
-      view.removeFirst()
+      view = view.dropFirst()
       view = view.drop(while: { $0 >= .init(ascii: "0") && $0 <= .init(ascii: "9") })
       view = view.drop(while: { $0 != .init(ascii: "-") })
       return view.starts(with: "-> () in ".utf8)

--- a/Sources/Perception/PerceptionRegistrar.swift
+++ b/Sources/Perception/PerceptionRegistrar.swift
@@ -268,9 +268,9 @@ extension PerceptionRegistrar: Hashable {
     }
     fileprivate var isActionClosure: Bool {
       var view = self[...].utf8
-      guard
-        view.starts(with: "closure #".utf8) || view.starts(with: "implicit closure #".utf8)
-      else { return false }
+      view = view.drop(while: { $0 != .init(ascii: "#") })
+      view.removeFirst()
+      view = view.drop(while: { $0 >= .init(ascii: "0") && $0 <= .init(ascii: "9") })
       view = view.drop(while: { $0 != .init(ascii: "-") })
       return view.starts(with: "-> () in ".utf8)
     }


### PR DESCRIPTION
Looks like demangled action closures have a slightly different format in iOS 15 than 16/17, so I generalized the `isActionClosure` helper a bit.