### PR TITLE
Added failing test for the alignmentGuide's computeValue closure

### DIFF
--- a/Tests/PerceptionTests/RuntimeWarningTests.swift
+++ b/Tests/PerceptionTests/RuntimeWarningTests.swift
@@ -311,6 +311,27 @@
 
       self.render(FeatureView())
     }
+      
+    func testAlignmentGuideComputeValueClosure() {
+      struct FeatureView: View {
+        @State var model = Model()
+        var body: some View {
+          WithPerceptionTracking {
+            VStack {
+              Text("Hello")
+                .alignmentGuide(HorizontalAlignment.center) {
+                  let _ = self.model.count
+                  return $0[HorizontalAlignment.center]
+                }
+                          
+              Text("World")
+            }
+          }
+        }
+      }
+      
+      self.render(FeatureView())
+    }
 
     func testRegistrarDisablePerceptionTracking() {
       struct FeatureView: View {


### PR DESCRIPTION
As per https://pointfreecommunity.slack.com/archives/C04KQQ7NXHV/p1708589849201589

The `alignmentGuide`'s trailing closure to compute the relevant view dimension seems to be invoked lazily by SwiftUI. This means that any state used in the closure will trigger a perception warning. The current workaround for this behavior (based on the code from the failing test) is:
```swift
WithPerceptionTracking {
  let count = self.model.count

  VStack {
    Text("Hello")
      .alignmentGuide(HorizontalAlignment.center) {
        let _ = count
        return $0[HorizontalAlignment.center]
      }

    Text("World")
  }
}
```

This works, but isn't very ergonomic.