### PR TITLE
Fix `$bindable.value.animation()`

### DIFF
--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -39,7 +39,7 @@ struct ContentView: View {
         }
         Button("Decrement") { model.decrementButtonTapped() }
         Button("Increment") { model.incrementButtonTapped() }
-        Toggle(isOn: $model.isDisplayingCount) {
+        Toggle(isOn: $model.isDisplayingCount.animation()) {
           Text("Display count?")
         }
         Button("Present sheet") {


### PR DESCRIPTION
Sadly, SwiftUI's `Binding.init(get:set:)` does not honor transactions/animations the same way that bindings derived from `@State`, `@ObservedObject`, etc., do, so our current backport of `@Bindable` fails to animate properly.

We can address this, thankfully, by projecting into a private observed object that wraps a perceptible one.