### PR TITLE
Drop Identifiable from Bindable.

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -356,6 +356,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = complete;
 			};
 			name = Debug;
 		};
@@ -411,6 +412,7 @@
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_STRICT_CONCURRENCY = complete;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
 
 for target in package.targets where target.type != .system {
   target.swiftSettings = target.swiftSettings ?? []
-  target.swiftSettings?.append(
-    .enableExperimentalFeature("StrictConcurrency")
-  )
+  target.swiftSettings?.append(contentsOf: [
+    .enableExperimentalFeature("StrictConcurrency"),
+  ])
 }

--- a/Sources/Perception/Bindable.swift
+++ b/Sources/Perception/Bindable.swift
@@ -58,15 +58,6 @@
   @available(macOS, introduced: 10.15, obsoleted: 14)
   @available(tvOS, introduced: 13, obsoleted: 17)
   @available(watchOS, introduced: 6, obsoleted: 10)
-  extension Bindable: Identifiable where Value: Identifiable {
-    /// The stable identity of the entity associated with this instance.
-    public var id: Value.ID { self.wrappedValue.id }
-  }
-
-  @available(iOS, introduced: 13, obsoleted: 17)
-  @available(macOS, introduced: 10.15, obsoleted: 14)
-  @available(tvOS, introduced: 13, obsoleted: 17)
-  @available(watchOS, introduced: 6, obsoleted: 10)
   extension Bindable: Sendable where Value: Sendable {}
 
   private final class Observer<Object>: ObservableObject {


### PR DESCRIPTION
We have a sendable warning due to `Bindable` becoming magically `@MainActor` since it holds onto an `@ObservedObject`. This is causing a problem with the `Identifiable` conformance, but we're not sure what use that conformance is so we are going to remove until we find a good reason for it.

BTW the `@MainActor` inference that is giving us trouble here is [going away](https://github.com/apple/swift-evolution/blob/main/proposals/0401-remove-property-wrapper-isolation.md) in Swift 6.