### PR TITLE
Raise the minimum supported version of `Observable` to iOS 17.0.1

### DIFF
--- a/Sources/Perception/Macros.swift
+++ b/Sources/Perception/Macros.swift
@@ -14,8 +14,8 @@
 
   @available(iOS, deprecated: 17.0.1, renamed: "Observable")
   @available(macOS, deprecated: 14, renamed: "Observable")
-  @available(tvOS, deprecated: 17, renamed: "Observable")
-  @available(watchOS, deprecated: 10, renamed: "Observable")
+  @available(tvOS, deprecated: 17.0.1, renamed: "Observable")
+  @available(watchOS, deprecated: 10.0.1, renamed: "Observable")
   @attached(
     member, names: named(_$id), named(_$perceptionRegistrar), named(access), named(withMutation))
   @attached(memberAttribute)
@@ -25,8 +25,8 @@
 
   @available(iOS, deprecated: 17.0.1, renamed: "ObservationTracked")
   @available(macOS, deprecated: 14, renamed: "ObservationTracked")
-  @available(tvOS, deprecated: 17, renamed: "ObservationTracked")
-  @available(watchOS, deprecated: 10, renamed: "ObservationTracked")
+  @available(tvOS, deprecated: 17.0.1, renamed: "ObservationTracked")
+  @available(watchOS, deprecated: 10.0.1, renamed: "ObservationTracked")
   @attached(accessor, names: named(init), named(get), named(set))
   @attached(peer, names: prefixed(_))
   public macro PerceptionTracked() =
@@ -34,8 +34,8 @@
 
   @available(iOS, deprecated: 17.0.1, renamed: "ObservationIgnored")
   @available(macOS, deprecated: 14, renamed: "ObservationIgnored")
-  @available(tvOS, deprecated: 17, renamed: "ObservationIgnored")
-  @available(watchOS, deprecated: 10, renamed: "ObservationIgnored")
+  @available(tvOS, deprecated: 17.0.1, renamed: "ObservationIgnored")
+  @available(watchOS, deprecated: 10.0.1, renamed: "ObservationIgnored")
   @attached(accessor, names: named(willSet))
   public macro PerceptionIgnored() =
     #externalMacro(module: "PerceptionMacros", type: "PerceptionIgnoredMacro")

--- a/Sources/Perception/Macros.swift
+++ b/Sources/Perception/Macros.swift
@@ -12,7 +12,7 @@
 #if canImport(Observation)
   import Observation
 
-  @available(iOS, deprecated: 17, renamed: "Observable")
+  @available(iOS, deprecated: 17.0.1, renamed: "Observable")
   @available(macOS, deprecated: 14, renamed: "Observable")
   @available(tvOS, deprecated: 17, renamed: "Observable")
   @available(watchOS, deprecated: 10, renamed: "Observable")
@@ -23,7 +23,7 @@
   public macro Perceptible() =
     #externalMacro(module: "PerceptionMacros", type: "PerceptibleMacro")
 
-  @available(iOS, deprecated: 17, renamed: "ObservationTracked")
+  @available(iOS, deprecated: 17.0.1, renamed: "ObservationTracked")
   @available(macOS, deprecated: 14, renamed: "ObservationTracked")
   @available(tvOS, deprecated: 17, renamed: "ObservationTracked")
   @available(watchOS, deprecated: 10, renamed: "ObservationTracked")
@@ -32,7 +32,7 @@
   public macro PerceptionTracked() =
     #externalMacro(module: "PerceptionMacros", type: "PerceptionTrackedMacro")
 
-  @available(iOS, deprecated: 17, renamed: "ObservationIgnored")
+  @available(iOS, deprecated: 17.0.1, renamed: "ObservationIgnored")
   @available(macOS, deprecated: 14, renamed: "ObservationIgnored")
   @available(tvOS, deprecated: 17, renamed: "ObservationIgnored")
   @available(watchOS, deprecated: 10, renamed: "ObservationIgnored")

--- a/Sources/Perception/Perceptible.swift
+++ b/Sources/Perception/Perceptible.swift
@@ -16,7 +16,7 @@
 /// type doesn't add observation functionality to the type. Instead, always use
 /// the ``Perception/Perceptible()`` macro when adding observation
 /// support to a type.
-@available(iOS, deprecated: 17, renamed: "Observable")
+@available(iOS, deprecated: 17.0.1, renamed: "Observable")
 @available(macOS, deprecated: 14, renamed: "Observable")
 @available(tvOS, deprecated: 17, renamed: "Observable")
 @available(watchOS, deprecated: 10, renamed: "Observable")

--- a/Sources/Perception/Perceptible.swift
+++ b/Sources/Perception/Perceptible.swift
@@ -18,6 +18,6 @@
 /// support to a type.
 @available(iOS, deprecated: 17.0.1, renamed: "Observable")
 @available(macOS, deprecated: 14, renamed: "Observable")
-@available(tvOS, deprecated: 17, renamed: "Observable")
-@available(watchOS, deprecated: 10, renamed: "Observable")
+@available(tvOS, deprecated: 17.0.1, renamed: "Observable")
+@available(watchOS, deprecated: 10.0.1, renamed: "Observable")
 public protocol Perceptible {}

--- a/Sources/Perception/PerceptionRegistrar.swift
+++ b/Sources/Perception/PerceptionRegistrar.swift
@@ -9,7 +9,7 @@ import SwiftUI
 ///
 /// You don't need to create an instance of `PerceptionRegistrar` when using
 /// the ``Perception/Perceptible()`` macro to indicate observability of a type.
-@available(iOS, deprecated: 17, renamed: "ObservationRegistrar")
+@available(iOS, deprecated: 17.0.1, renamed: "ObservationRegistrar")
 @available(macOS, deprecated: 14, renamed: "ObservationRegistrar")
 @available(tvOS, deprecated: 17, renamed: "ObservationRegistrar")
 @available(watchOS, deprecated: 10, renamed: "ObservationRegistrar")
@@ -27,7 +27,7 @@ public struct PerceptionRegistrar: Sendable {
   /// ``Perception/Perceptible()`` macro to indicate observably
   /// of a type.
   public init(isPerceptionCheckingEnabled: Bool = Perception.isPerceptionCheckingEnabled) {
-    if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
+      if #available(iOS 17.0.1, macOS 14, tvOS 17, watchOS 10, *) {
       #if canImport(Observation)
         self._rawValue = AnySendable(ObservationRegistrar())
       #else
@@ -42,7 +42,7 @@ public struct PerceptionRegistrar: Sendable {
   }
 
   #if canImport(Observation)
-    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @available(iOS 17.0.1, macOS 14, tvOS 17, watchOS 10, *)
     private var registrar: ObservationRegistrar {
       self._rawValue.base as! ObservationRegistrar
     }
@@ -54,7 +54,7 @@ public struct PerceptionRegistrar: Sendable {
 }
 
 #if canImport(Observation)
-  @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+  @available(iOS 17.0.1, macOS 14, tvOS 17, watchOS 10, *)
   extension PerceptionRegistrar {
     public func access<Subject: Observable, Member>(
       _ subject: Subject, keyPath: KeyPath<Subject, Member>
@@ -94,7 +94,7 @@ extension PerceptionRegistrar {
       self.perceptionCheck(file: file, line: line)
     #endif
     #if canImport(Observation)
-      if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
+      if #available(iOS 17.0.1, macOS 14, tvOS 17, watchOS 10, *) {
         func `open`<T: Observable>(_ subject: T) {
           self.registrar.access(
             subject,
@@ -117,7 +117,7 @@ extension PerceptionRegistrar {
     _ mutation: () throws -> T
   ) rethrows -> T {
     #if canImport(Observation)
-      if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *),
+      if #available(iOS 17.0.1, macOS 14, tvOS 17, watchOS 10, *),
         let subject = subject as? any Observable
       {
         func `open`<S: Observable>(_ subject: S) throws -> T {
@@ -142,7 +142,7 @@ extension PerceptionRegistrar {
     keyPath: KeyPath<Subject, Member>
   ) {
     #if canImport(Observation)
-      if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *),
+      if #available(iOS 17.0.1, macOS 14, tvOS 17, watchOS 10, *),
         let subject = subject as? any Observable
       {
         func `open`<S: Observable>(_ subject: S) {
@@ -164,7 +164,7 @@ extension PerceptionRegistrar {
     keyPath: KeyPath<Subject, Member>
   ) {
     #if canImport(Observation)
-      if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *),
+      if #available(iOS 17.0.1, macOS 14, tvOS 17, watchOS 10, *),
         let subject = subject as? any Observable
       {
         func `open`<S: Observable>(_ subject: S) {
@@ -315,7 +315,7 @@ extension PerceptionRegistrar: Hashable {
 #endif
 
 #if DEBUG
-  @available(iOS, deprecated: 17)
+  @available(iOS, deprecated: 17.0.1)
   @available(macOS, deprecated: 14)
   @available(tvOS, deprecated: 17)
   @available(watchOS, deprecated: 10)
@@ -327,7 +327,7 @@ extension PerceptionRegistrar: Hashable {
     }
   }
 #else
-  @available(iOS, deprecated: 17)
+  @available(iOS, deprecated: 17.0.1)
   @available(macOS, deprecated: 14)
   @available(tvOS, deprecated: 17)
   @available(watchOS, deprecated: 10)

--- a/Sources/Perception/PerceptionRegistrar.swift
+++ b/Sources/Perception/PerceptionRegistrar.swift
@@ -11,8 +11,8 @@ import SwiftUI
 /// the ``Perception/Perceptible()`` macro to indicate observability of a type.
 @available(iOS, deprecated: 17.0.1, renamed: "ObservationRegistrar")
 @available(macOS, deprecated: 14, renamed: "ObservationRegistrar")
-@available(tvOS, deprecated: 17, renamed: "ObservationRegistrar")
-@available(watchOS, deprecated: 10, renamed: "ObservationRegistrar")
+@available(tvOS, deprecated: 17.0.1, renamed: "ObservationRegistrar")
+@available(watchOS, deprecated: 10.0.1, renamed: "ObservationRegistrar")
 public struct PerceptionRegistrar: Sendable {
   private let _rawValue: AnySendable
   #if DEBUG
@@ -27,7 +27,7 @@ public struct PerceptionRegistrar: Sendable {
   /// ``Perception/Perceptible()`` macro to indicate observably
   /// of a type.
   public init(isPerceptionCheckingEnabled: Bool = Perception.isPerceptionCheckingEnabled) {
-      if #available(iOS 17.0.1, macOS 14, tvOS 17, watchOS 10, *) {
+      if #available(iOS 17.0.1, macOS 14, tvOS 17.0.1, watchOS 10.0.1, *) {
       #if canImport(Observation)
         self._rawValue = AnySendable(ObservationRegistrar())
       #else
@@ -42,7 +42,7 @@ public struct PerceptionRegistrar: Sendable {
   }
 
   #if canImport(Observation)
-    @available(iOS 17.0.1, macOS 14, tvOS 17, watchOS 10, *)
+    @available(iOS 17.0.1, macOS 14, tvOS 17.0.1, watchOS 10.0.1, *)
     private var registrar: ObservationRegistrar {
       self._rawValue.base as! ObservationRegistrar
     }
@@ -54,7 +54,7 @@ public struct PerceptionRegistrar: Sendable {
 }
 
 #if canImport(Observation)
-  @available(iOS 17.0.1, macOS 14, tvOS 17, watchOS 10, *)
+  @available(iOS 17.0.1, macOS 14, tvOS 17.0.1, watchOS 10.0.1, *)
   extension PerceptionRegistrar {
     public func access<Subject: Observable, Member>(
       _ subject: Subject, keyPath: KeyPath<Subject, Member>
@@ -94,7 +94,7 @@ extension PerceptionRegistrar {
       self.perceptionCheck(file: file, line: line)
     #endif
     #if canImport(Observation)
-      if #available(iOS 17.0.1, macOS 14, tvOS 17, watchOS 10, *) {
+      if #available(iOS 17.0.1, macOS 14, tvOS 17.0.1, watchOS 10.0.1, *) {
         func `open`<T: Observable>(_ subject: T) {
           self.registrar.access(
             subject,
@@ -117,7 +117,7 @@ extension PerceptionRegistrar {
     _ mutation: () throws -> T
   ) rethrows -> T {
     #if canImport(Observation)
-      if #available(iOS 17.0.1, macOS 14, tvOS 17, watchOS 10, *),
+      if #available(iOS 17.0.1, macOS 14, tvOS 17.0.1, watchOS 10.0.1, *),
         let subject = subject as? any Observable
       {
         func `open`<S: Observable>(_ subject: S) throws -> T {
@@ -142,7 +142,7 @@ extension PerceptionRegistrar {
     keyPath: KeyPath<Subject, Member>
   ) {
     #if canImport(Observation)
-      if #available(iOS 17.0.1, macOS 14, tvOS 17, watchOS 10, *),
+      if #available(iOS 17.0.1, macOS 14, tvOS 17.0.1, watchOS 10.0.1, *),
         let subject = subject as? any Observable
       {
         func `open`<S: Observable>(_ subject: S) {
@@ -164,7 +164,7 @@ extension PerceptionRegistrar {
     keyPath: KeyPath<Subject, Member>
   ) {
     #if canImport(Observation)
-      if #available(iOS 17.0.1, macOS 14, tvOS 17, watchOS 10, *),
+      if #available(iOS 17.0.1, macOS 14, tvOS 17.0.1, watchOS 10.0.1, *),
         let subject = subject as? any Observable
       {
         func `open`<S: Observable>(_ subject: S) {
@@ -317,8 +317,8 @@ extension PerceptionRegistrar: Hashable {
 #if DEBUG
   @available(iOS, deprecated: 17.0.1)
   @available(macOS, deprecated: 14)
-  @available(tvOS, deprecated: 17)
-  @available(watchOS, deprecated: 10)
+  @available(tvOS, deprecated: 17.0.1)
+  @available(watchOS, deprecated: 10.0.1)
   public func _withoutPerceptionChecking<T>(
     _ apply: () -> T
   ) -> T {
@@ -329,8 +329,8 @@ extension PerceptionRegistrar: Hashable {
 #else
   @available(iOS, deprecated: 17.0.1)
   @available(macOS, deprecated: 14)
-  @available(tvOS, deprecated: 17)
-  @available(watchOS, deprecated: 10)
+  @available(tvOS, deprecated: 17.0.1)
+  @available(watchOS, deprecated: 10.0.1)
   @_transparent
   @inline(__always)
   public func _withoutPerceptionChecking<T>(

--- a/Sources/Perception/PerceptionTracking.swift
+++ b/Sources/Perception/PerceptionTracking.swift
@@ -209,7 +209,7 @@ private func generateAccessList<T>(_ apply: () -> T) -> (T, PerceptionTracking._
 ///
 /// - Returns: The value that the `apply` closure returns if it has a return
 /// value; otherwise, there is no return value.
-@available(iOS, deprecated: 17, renamed: "withObservationTracking")
+@available(iOS, deprecated: 17.0.1, renamed: "withObservationTracking")
 @available(macOS, deprecated: 14, renamed: "withObservationTracking")
 @available(tvOS, deprecated: 17, renamed: "withObservationTracking")
 @available(watchOS, deprecated: 10, renamed: "withObservationTracking")
@@ -218,7 +218,7 @@ public func withPerceptionTracking<T>(
   onChange: @autoclosure () -> @Sendable () -> Void
 ) -> T {
   #if canImport(Observation)
-    if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
+    if #available(iOS 17.0.1, macOS 14, tvOS 17, watchOS 10, *) {
       return withObservationTracking(apply, onChange: onChange())
     }
   #endif

--- a/Sources/Perception/PerceptionTracking.swift
+++ b/Sources/Perception/PerceptionTracking.swift
@@ -211,14 +211,14 @@ private func generateAccessList<T>(_ apply: () -> T) -> (T, PerceptionTracking._
 /// value; otherwise, there is no return value.
 @available(iOS, deprecated: 17.0.1, renamed: "withObservationTracking")
 @available(macOS, deprecated: 14, renamed: "withObservationTracking")
-@available(tvOS, deprecated: 17, renamed: "withObservationTracking")
-@available(watchOS, deprecated: 10, renamed: "withObservationTracking")
+@available(tvOS, deprecated: 17.0.1, renamed: "withObservationTracking")
+@available(watchOS, deprecated: 10.0.1, renamed: "withObservationTracking")
 public func withPerceptionTracking<T>(
   _ apply: () -> T,
   onChange: @autoclosure () -> @Sendable () -> Void
 ) -> T {
   #if canImport(Observation)
-    if #available(iOS 17.0.1, macOS 14, tvOS 17, watchOS 10, *) {
+    if #available(iOS 17.0.1, macOS 14, tvOS 17.0.1, watchOS 10.0.1, *) {
       return withObservationTracking(apply, onChange: onChange())
     }
   #endif

--- a/Sources/Perception/WithPerceptionTracking.swift
+++ b/Sources/Perception/WithPerceptionTracking.swift
@@ -40,14 +40,14 @@ import SwiftUI
 /// inside ``WithPerceptionTracking``.
 @available(iOS, deprecated: 17.0.1, message: "Remove WithPerceptionTracking")
 @available(macOS, deprecated: 14, message: "Remove WithPerceptionTracking")
-@available(tvOS, deprecated: 17, message: "Remove WithPerceptionTracking")
-@available(watchOS, deprecated: 10, message: "Remove WithPerceptionTracking")
+@available(tvOS, deprecated: 17.0.1, message: "Remove WithPerceptionTracking")
+@available(watchOS, deprecated: 10.0.1, message: "Remove WithPerceptionTracking")
 public struct WithPerceptionTracking<Content> {
   @State var id = 0
   let content: () -> Content
 
   public var body: Content {
-    if #available(iOS 17.0.1, macOS 14, tvOS 17, watchOS 10, *) {
+    if #available(iOS 17.0.1, macOS 14, tvOS 17.0.1, watchOS 10.0.1, *) {
       return self.instrumentedBody()
     } else {
       // NB: View will not re-render when 'id' changes unless we access it in the view.
@@ -158,8 +158,8 @@ extension WithPerceptionTracking: View where Content: View {
 
 @available(iOS, deprecated: 17.0.1)
 @available(macOS, deprecated: 14)
-@available(tvOS, deprecated: 17)
-@available(watchOS, deprecated: 10)
+@available(tvOS, deprecated: 17.0.1)
+@available(watchOS, deprecated: 10.0.1)
 public enum _PerceptionLocals {
   @TaskLocal public static var isInPerceptionTracking = false
   @TaskLocal public static var skipPerceptionChecking = false

--- a/Sources/Perception/WithPerceptionTracking.swift
+++ b/Sources/Perception/WithPerceptionTracking.swift
@@ -38,7 +38,7 @@ import SwiftUI
 /// To debug this, expand the warning in the Issue Navigator of Xcode (cmd+5), and click through the
 /// stack frames displayed to find the line in your view where you are accessing state without being
 /// inside ``WithPerceptionTracking``.
-@available(iOS, deprecated: 17, message: "Remove WithPerceptionTracking")
+@available(iOS, deprecated: 17.0.1, message: "Remove WithPerceptionTracking")
 @available(macOS, deprecated: 14, message: "Remove WithPerceptionTracking")
 @available(tvOS, deprecated: 17, message: "Remove WithPerceptionTracking")
 @available(watchOS, deprecated: 10, message: "Remove WithPerceptionTracking")
@@ -47,7 +47,7 @@ public struct WithPerceptionTracking<Content> {
   let content: () -> Content
 
   public var body: Content {
-    if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
+    if #available(iOS 17.0.1, macOS 14, tvOS 17, watchOS 10, *) {
       return self.instrumentedBody()
     } else {
       // NB: View will not re-render when 'id' changes unless we access it in the view.
@@ -156,7 +156,7 @@ extension WithPerceptionTracking: View where Content: View {
   }
 }
 
-@available(iOS, deprecated: 17)
+@available(iOS, deprecated: 17.0.1)
 @available(macOS, deprecated: 14)
 @available(tvOS, deprecated: 17)
 @available(watchOS, deprecated: 10)

--- a/Sources/PerceptionMacros/PerceptibleMacro.swift
+++ b/Sources/PerceptionMacros/PerceptibleMacro.swift
@@ -302,7 +302,7 @@ extension PerceptibleMacro: ExtensionMacro {
       extension \(raw: type.trimmedDescription): \(raw: qualifiedConformanceName) {}
       """
     let obsDecl: DeclSyntax = """
-      @available(iOS 17.0.1, macOS 14, tvOS 17, watchOS 10, *)
+      @available(iOS 17.0.1, macOS 14, tvOS 17.0.1, watchOS 10.0.1, *)
       extension \(raw: type.trimmedDescription): Observation.Observable {}
       """
     let ext = decl.cast(ExtensionDeclSyntax.self)

--- a/Sources/PerceptionMacros/PerceptibleMacro.swift
+++ b/Sources/PerceptionMacros/PerceptibleMacro.swift
@@ -302,7 +302,7 @@ extension PerceptibleMacro: ExtensionMacro {
       extension \(raw: type.trimmedDescription): \(raw: qualifiedConformanceName) {}
       """
     let obsDecl: DeclSyntax = """
-      @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+      @available(iOS 17.0.1, macOS 14, tvOS 17, watchOS 10, *)
       extension \(raw: type.trimmedDescription): Observation.Observable {}
       """
     let ext = decl.cast(ExtensionDeclSyntax.self)


### PR DESCRIPTION
Some users on iOS 17.0.0 are unable to use Composable Architecture due to a EXC_BAD_ACCESS crash when casting `subject` to `any Observable` . 

> @stephencelis: Early versions of observation used a @_marker protocol for Observable, and so that might account for the crash

This raises the minimum version to iOS 17.0.1 where the crash does not occur. 

```
(lldb) po subject is Observable
true
(lldb) po subject as? any Observable
error: Execution was interrupted, reason: EXC_BAD_ACCESS (code=1, address=0x0).
The process has been returned to the state before expression evaluation.
```

```
EXC_BAD_ACCESS (KERN_INVALID_ADDRESS)
0  libswiftCore.dylib             0x39be20 tryCast(swift::OpaqueValue*, swift::TargetMetadata<swift::InProcess> const*, swift::OpaqueValue*, swift::TargetMetadata<swift::InProcess> const*, swift::TargetMetadata<swift::InProcess> const*&, swift::TargetMetadata<swift::InProcess> const*&, bool, bool) + 84
1  libswiftCore.dylib             0x39bc58 swift_dynamicCast + 208
2  Perception                     0x9764 PerceptionRegistrar.access<A, B>(_:keyPath:file:line:) + 103 (PerceptionRegistrar.swift:103)
3  ComposableArchitecture         0x38d44 Store<>.state.getter + 18 (Store+Observation.swift:18)
```

Slack Thread: https://pointfreecommunity.slack.com/archives/C04KQQ7NXHV/p1712927043813189