### PR TITLE
Don't warn on visionOS

### DIFF
--- a/Sources/Perception/Bindable.swift
+++ b/Sources/Perception/Bindable.swift
@@ -9,7 +9,7 @@
   @available(macOS, introduced: 10.15, obsoleted: 14, message: "Use @Bindable without the 'Perception.' prefix.")
   @available(tvOS, introduced: 13, obsoleted: 17, message: "Use @Bindable without the 'Perception.' prefix.")
   @available(watchOS, introduced: 6, obsoleted: 10, message: "Use @Bindable without the 'Perception.' prefix.")
-  @available(visionOS, unavailable, message: "Use @Bindable without the 'Perception.' prefix.")
+  @available(visionOS, obsoleted: 9999, message: "Use @Bindable without the 'Perception.' prefix.")
   @dynamicMemberLookup
   @propertyWrapper
   public struct Bindable<Value> {

--- a/Sources/Perception/Perceptible.swift
+++ b/Sources/Perception/Perceptible.swift
@@ -19,5 +19,6 @@
 @available(iOS, deprecated: 17, renamed: "Observable")
 @available(macOS, deprecated: 14, renamed: "Observable")
 @available(tvOS, deprecated: 17, renamed: "Observable")
+@available(visionOS, deprecated: 9999, renamed: "Observable")
 @available(watchOS, deprecated: 10, renamed: "Observable")
 public protocol Perceptible {}

--- a/Sources/Perception/PerceptionRegistrar.swift
+++ b/Sources/Perception/PerceptionRegistrar.swift
@@ -12,6 +12,7 @@ import SwiftUI
 @available(iOS, deprecated: 17, renamed: "ObservationRegistrar")
 @available(macOS, deprecated: 14, renamed: "ObservationRegistrar")
 @available(tvOS, deprecated: 17, renamed: "ObservationRegistrar")
+@available(visionOS, deprecated: 9999, renamed: "ObservationRegistrar")
 @available(watchOS, deprecated: 10, renamed: "ObservationRegistrar")
 public struct PerceptionRegistrar: Sendable {
   private let _rawValue: AnySendable

--- a/Sources/Perception/PerceptionTracking.swift
+++ b/Sources/Perception/PerceptionTracking.swift
@@ -212,6 +212,7 @@ private func generateAccessList<T>(_ apply: () -> T) -> (T, PerceptionTracking._
 @available(iOS, deprecated: 17, renamed: "withObservationTracking")
 @available(macOS, deprecated: 14, renamed: "withObservationTracking")
 @available(tvOS, deprecated: 17, renamed: "withObservationTracking")
+@available(visionOS, deprecated: 9999, renamed: "withObservationTracking")
 @available(watchOS, deprecated: 10, renamed: "withObservationTracking")
 public func withPerceptionTracking<T>(
   _ apply: () -> T,

--- a/Sources/Perception/WithPerceptionTracking.swift
+++ b/Sources/Perception/WithPerceptionTracking.swift
@@ -41,6 +41,7 @@ import SwiftUI
 @available(iOS, deprecated: 17, message: "Remove WithPerceptionTracking")
 @available(macOS, deprecated: 14, message: "Remove WithPerceptionTracking")
 @available(tvOS, deprecated: 17, message: "Remove WithPerceptionTracking")
+@available(visionOS, deprecated: 9999, message: "Remove WithPerceptionTracking")
 @available(watchOS, deprecated: 10, message: "Remove WithPerceptionTracking")
 public struct WithPerceptionTracking<Content> {
   @State var id = 0
@@ -159,6 +160,7 @@ extension WithPerceptionTracking: View where Content: View {
 @available(iOS, deprecated: 17)
 @available(macOS, deprecated: 14)
 @available(tvOS, deprecated: 17)
+@available(visionOS, deprecated: 9999)
 @available(watchOS, deprecated: 10)
 public enum _PerceptionLocals {
   @TaskLocal public static var isInPerceptionTracking = false


### PR DESCRIPTION
Because all visionOS deployment targets support observation, these warnings can be quite noisy.