### PR TITLE
Prevent overflow error in WithPerceptionTracking id

### DIFF
--- a/Sources/Perception/WithPerceptionTracking.swift
+++ b/Sources/Perception/WithPerceptionTracking.swift
@@ -56,7 +56,7 @@ public struct WithPerceptionTracking<Content> {
       return withPerceptionTracking {
         self.instrumentedBody()
       } onChange: { [_id = UncheckedSendable(self._id)] in
-        _id.value.wrappedValue += 1
+        _id.value.wrappedValue &+= 1
       }
     }
   }


### PR DESCRIPTION
Using &+= operator to prevent int overflow errors, the same as _PerceptionRegistrar's generateId.

https://github.com/pointfreeco/swift-perception/blob/main/Sources/Perception/Internal/_PerceptionRegistrar.swift#L111