### PR TITLE
Make `Bindable` unavailable to visionOS

### DIFF
--- a/Sources/Perception/Bindable.swift
+++ b/Sources/Perception/Bindable.swift
@@ -5,26 +5,7 @@
   /// perceptible objects.
   ///
   /// A backport of SwiftUI's `Bindable` property wrapper.
-  @available(
-    iOS, introduced: 13, obsoleted: 17,
-    message: "Use '@Bindable' without the 'Perception.' prefix."
-  )
-  @available(
-    macOS, introduced: 10.15, obsoleted: 14,
-    message: "Use '@Bindable' without the 'Perception.' prefix."
-  )
-  @available(
-    tvOS, introduced: 13, obsoleted: 17,
-    message: "Use '@Bindable' without the 'Perception.' prefix."
-  )
-  @available(
-    visionOS, unavailable,
-    message: "Use '@Bindable' without the 'Perception.' prefix."
-  )
-  @available(
-    watchOS, introduced: 6, obsoleted: 10,
-    message: "Use '@Bindable' without the 'Perception.' prefix."
-  )
+  @available(visionOS, unavailable)
   @dynamicMemberLookup
   @propertyWrapper
   public struct Bindable<Value> {
@@ -69,10 +50,7 @@
     }
   }
 
-  @available(iOS, introduced: 13, obsoleted: 17)
-  @available(macOS, introduced: 10.15, obsoleted: 14)
-  @available(tvOS, introduced: 13, obsoleted: 17)
-  @available(watchOS, introduced: 6, obsoleted: 10)
+  @available(visionOS, unavailable)
   extension Bindable: Sendable where Value: Sendable {}
 
   private final class Observer<Object>: ObservableObject {

--- a/Sources/Perception/Bindable.swift
+++ b/Sources/Perception/Bindable.swift
@@ -5,11 +5,26 @@
   /// perceptible objects.
   ///
   /// A backport of SwiftUI's `Bindable` property wrapper.
-  @available(iOS, introduced: 13, obsoleted: 17, message: "Use @Bindable without the 'Perception.' prefix.")
-  @available(macOS, introduced: 10.15, obsoleted: 14, message: "Use @Bindable without the 'Perception.' prefix.")
-  @available(tvOS, introduced: 13, obsoleted: 17, message: "Use @Bindable without the 'Perception.' prefix.")
-  @available(watchOS, introduced: 6, obsoleted: 10, message: "Use @Bindable without the 'Perception.' prefix.")
-  @available(visionOS, obsoleted: 9999, message: "Use @Bindable without the 'Perception.' prefix.")
+  @available(
+    iOS, introduced: 13, obsoleted: 17,
+    message: "Use '@Bindable' without the 'Perception.' prefix."
+  )
+  @available(
+    macOS, introduced: 10.15, obsoleted: 14,
+    message: "Use '@Bindable' without the 'Perception.' prefix."
+  )
+  @available(
+    tvOS, introduced: 13, obsoleted: 17,
+    message: "Use '@Bindable' without the 'Perception.' prefix."
+  )
+  @available(
+    visionOS, unavailable,
+    message: "Use '@Bindable' without the 'Perception.' prefix."
+  )
+  @available(
+    watchOS, introduced: 6, obsoleted: 10,
+    message: "Use '@Bindable' without the 'Perception.' prefix."
+  )
   @dynamicMemberLookup
   @propertyWrapper
   public struct Bindable<Value> {

--- a/Sources/Perception/Environment.swift
+++ b/Sources/Perception/Environment.swift
@@ -1,11 +1,6 @@
 #if canImport(SwiftUI)
   import SwiftUI
 
-  @available(iOS, introduced: 13, obsoleted: 17)
-  @available(macOS, introduced: 10.15, obsoleted: 14)
-  @available(tvOS, introduced: 13, obsoleted: 17)
-  @available(watchOS, introduced: 6, obsoleted: 10)
-  @available(visionOS, unavailable)
   extension Environment {
     /// Creates an environment property to read a perceptible object from the environment.
     ///
@@ -29,11 +24,6 @@
     }
   }
 
-  @available(iOS, introduced: 13, obsoleted: 17)
-  @available(macOS, introduced: 10.15, obsoleted: 14)
-  @available(tvOS, introduced: 13, obsoleted: 17)
-  @available(watchOS, introduced: 6, obsoleted: 10)
-  @available(visionOS, unavailable)
   extension View {
     /// Places a perceptible object in the view’s environment.
     ///

--- a/Sources/Perception/Internal/Locals.swift
+++ b/Sources/Perception/Internal/Locals.swift
@@ -1,8 +1,3 @@
-@available(iOS, deprecated: 17)
-@available(macOS, deprecated: 14)
-@available(tvOS, deprecated: 17)
-@available(visionOS, deprecated: 9999)
-@available(watchOS, deprecated: 10)
 public enum _PerceptionLocals {
   @TaskLocal public static var isInPerceptionTracking = false
   @TaskLocal public static var skipPerceptionChecking = false

--- a/Sources/Perception/Macros.swift
+++ b/Sources/Perception/Macros.swift
@@ -9,10 +9,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(iOS, deprecated: 17, renamed: "Observable")
-@available(macOS, deprecated: 14, renamed: "Observable")
-@available(tvOS, deprecated: 17, renamed: "Observable")
-@available(watchOS, deprecated: 10, renamed: "Observable")
 @attached(
   member, names: named(_$id), named(_$perceptionRegistrar), named(access), named(withMutation))
 @attached(memberAttribute)
@@ -20,19 +16,11 @@
 public macro Perceptible() =
   #externalMacro(module: "PerceptionMacros", type: "PerceptibleMacro")
 
-@available(iOS, deprecated: 17, renamed: "ObservationTracked")
-@available(macOS, deprecated: 14, renamed: "ObservationTracked")
-@available(tvOS, deprecated: 17, renamed: "ObservationTracked")
-@available(watchOS, deprecated: 10, renamed: "ObservationTracked")
 @attached(accessor, names: named(init), named(get), named(set))
 @attached(peer, names: prefixed(_))
 public macro PerceptionTracked() =
   #externalMacro(module: "PerceptionMacros", type: "PerceptionTrackedMacro")
 
-@available(iOS, deprecated: 17, renamed: "ObservationIgnored")
-@available(macOS, deprecated: 14, renamed: "ObservationIgnored")
-@available(tvOS, deprecated: 17, renamed: "ObservationIgnored")
-@available(watchOS, deprecated: 10, renamed: "ObservationIgnored")
 @attached(accessor, names: named(willSet))
 public macro PerceptionIgnored() =
   #externalMacro(module: "PerceptionMacros", type: "PerceptionIgnoredMacro")

--- a/Sources/Perception/Perceptible.swift
+++ b/Sources/Perception/Perceptible.swift
@@ -16,9 +16,4 @@
 /// type doesn't add observation functionality to the type. Instead, always use
 /// the ``Perception/Perceptible()`` macro when adding observation
 /// support to a type.
-@available(iOS, deprecated: 17, renamed: "Observable")
-@available(macOS, deprecated: 14, renamed: "Observable")
-@available(tvOS, deprecated: 17, renamed: "Observable")
-@available(visionOS, deprecated: 9999, renamed: "Observable")
-@available(watchOS, deprecated: 10, renamed: "Observable")
 public protocol Perceptible {}

--- a/Sources/Perception/PerceptionRegistrar.swift
+++ b/Sources/Perception/PerceptionRegistrar.swift
@@ -4,11 +4,6 @@ import Foundation
 ///
 /// You don't need to create an instance of `PerceptionRegistrar` when using
 /// the ``Perception/Perceptible()`` macro to indicate observability of a type.
-@available(iOS, deprecated: 17, renamed: "ObservationRegistrar")
-@available(macOS, deprecated: 14, renamed: "ObservationRegistrar")
-@available(tvOS, deprecated: 17, renamed: "ObservationRegistrar")
-@available(visionOS, deprecated: 9999, renamed: "ObservationRegistrar")
-@available(watchOS, deprecated: 10, renamed: "ObservationRegistrar")
 public struct PerceptionRegistrar: Sendable {
   private let _rawValue: AnySendable
   #if DEBUG
@@ -305,10 +300,6 @@ extension PerceptionRegistrar: Hashable {
 #endif
 
 #if DEBUG
-  @available(iOS, deprecated: 17)
-  @available(macOS, deprecated: 14)
-  @available(tvOS, deprecated: 17)
-  @available(watchOS, deprecated: 10)
   public func _withoutPerceptionChecking<T>(
     _ apply: () -> T
   ) -> T {
@@ -317,10 +308,6 @@ extension PerceptionRegistrar: Hashable {
     }
   }
 #else
-  @available(iOS, deprecated: 17)
-  @available(macOS, deprecated: 14)
-  @available(tvOS, deprecated: 17)
-  @available(watchOS, deprecated: 10)
   @_transparent
   @inline(__always)
   public func _withoutPerceptionChecking<T>(

--- a/Sources/Perception/PerceptionTracking.swift
+++ b/Sources/Perception/PerceptionTracking.swift
@@ -205,11 +205,6 @@ private func generateAccessList<T>(_ apply: () -> T) -> (T, PerceptionTracking._
 ///
 /// - Returns: The value that the `apply` closure returns if it has a return
 /// value; otherwise, there is no return value.
-@available(iOS, deprecated: 17, renamed: "withObservationTracking")
-@available(macOS, deprecated: 14, renamed: "withObservationTracking")
-@available(tvOS, deprecated: 17, renamed: "withObservationTracking")
-@available(visionOS, deprecated: 9999, renamed: "withObservationTracking")
-@available(watchOS, deprecated: 10, renamed: "withObservationTracking")
 public func withPerceptionTracking<T>(
   _ apply: () -> T,
   onChange: @autoclosure () -> @Sendable () -> Void

--- a/Sources/Perception/WithPerceptionTracking.swift
+++ b/Sources/Perception/WithPerceptionTracking.swift
@@ -39,11 +39,6 @@
   /// To debug this, expand the warning in the Issue Navigator of Xcode (cmd+5), and click through
   /// the stack frames displayed to find the line in your view where you are accessing state without
   /// being inside ``WithPerceptionTracking``.
-  @available(iOS, deprecated: 17, message: "Remove WithPerceptionTracking")
-  @available(macOS, deprecated: 14, message: "Remove WithPerceptionTracking")
-  @available(tvOS, deprecated: 17, message: "Remove WithPerceptionTracking")
-  @available(visionOS, deprecated: 9999, message: "Remove WithPerceptionTracking")
-  @available(watchOS, deprecated: 10, message: "Remove WithPerceptionTracking")
   public struct WithPerceptionTracking<Content> {
     @State var id = 0
     let content: () -> Content


### PR DESCRIPTION
Fixes #76.

I'm wondering if we should revisit the deprecations in general.