### PR TITLE
Support swift-syntax from 600.0.0-latest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     .library(name: "Perception", targets: ["Perception"])
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax", "509.0.0"..<"511.0.0"),
+    .package(url: "https://github.com/apple/swift-syntax", "509.0.0"..<"601.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.1.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.0.0"),
   ],


### PR DESCRIPTION
The Xcode 16 beta generates macro projects using these swift-syntax snapshots. Luckily things seem to be backwards compatible, so we can expand our supported range.