### PR TITLE
Unpin doc gen Swift version

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,4 +2,3 @@ version: 1
 builder:
   configs:
   - documentation_targets: [Perception]
-    swift_version: 5.8


### PR DESCRIPTION
The Swift version for doc generation is pinned to 5.8, which the package doesn't support anymore. That's why docs haven't been updated since 1.0.0.