### PR TITLE
Support Swift Charts

### DIFF
--- a/Sources/Perception/WithPerceptionTracking.swift
+++ b/Sources/Perception/WithPerceptionTracking.swift
@@ -152,4 +152,16 @@
       self.content = content
     }
   }
+
+  #if canImport(Charts)
+    import Charts
+
+    @available(macOS 13.0, *)
+    @available(iOS 16.0, *)
+    extension WithPerceptionTracking: ChartContent where Content: ChartContent {
+      public init(@ChartContentBuilder content: @escaping () -> Content) {
+        self.content = content
+      }
+    }
+  #endif
 #endif


### PR DESCRIPTION
Hi, I have made modifications to allow the use of WithPerceptionTracking within the ChartContentBuilder.
```Swift
Chart {
    WithPerceptionTracking {
        ...
    }
}
```