### PR TITLE
Fix tvOS/watchOS builds

### DIFF
--- a/Sources/Perception/WithPerceptionTracking.swift
+++ b/Sources/Perception/WithPerceptionTracking.swift
@@ -156,8 +156,7 @@
   #if canImport(Charts)
     import Charts
 
-    @available(macOS 13.0, *)
-    @available(iOS 16.0, *)
+    @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
     extension WithPerceptionTracking: ChartContent where Content: ChartContent {
       public init(@ChartContentBuilder content: @escaping () -> Content) {
         self.content = content


### PR DESCRIPTION
A regression in tvOS/watchOS builds was introduced #86 because availability wasn't specified. This should fix!