### PR TITLE
Fix Swift 5.9

### DIFF
--- a/Sources/PerceptionCore/Internal/ThreadLocal.swift
+++ b/Sources/PerceptionCore/Internal/ThreadLocal.swift
@@ -13,7 +13,12 @@ import Foundation
 
 struct _ThreadLocal {
   #if os(WASI)
-    static nonisolated(unsafe) var value: UnsafeMutableRawPointer?
+    // NB: This can simply be 'nonisolated(unsafe)' when we drop support for Swift 5.9
+    static var value: UnsafeMutableRawPointer? {
+      get { _value.value }
+      set { _value.value = newValue }
+    }
+    private let _value = UncheckedSendable<UnsafeMutableRawPointer?>(nil)
   #else
     static var value: UnsafeMutableRawPointer? {
       get { Thread.current.threadDictionary[Key()] as! UnsafeMutableRawPointer? }

--- a/Sources/PerceptionCore/Internal/ThreadLocal.swift
+++ b/Sources/PerceptionCore/Internal/ThreadLocal.swift
@@ -18,7 +18,7 @@ struct _ThreadLocal {
       get { _value.value }
       set { _value.value = newValue }
     }
-    private let _value = UncheckedSendable<UnsafeMutableRawPointer?>(nil)
+    private static let _value = UncheckedBox<UnsafeMutableRawPointer?>(nil)
   #else
     static var value: UnsafeMutableRawPointer? {
       get { Thread.current.threadDictionary[Key()] as! UnsafeMutableRawPointer? }

--- a/Sources/PerceptionCore/Internal/Unchecked.swift
+++ b/Sources/PerceptionCore/Internal/Unchecked.swift
@@ -1,3 +1,9 @@
+@usableFromInline final class UncheckedBox<Value>: @unchecked Sendable {
+  @usableFromInline var value: Value
+  @usableFromInline init(_ value: Value) {
+    self.value = value
+  }
+}
 @usableFromInline struct UncheckedSendable<Value>: @unchecked Sendable {
   @usableFromInline let value: Value
   @usableFromInline init(_ value: Value) {


### PR DESCRIPTION
Unfortunately `nonisolated(unsafe)` seems to confuse the 5.9 compiler even when it appears in an `#if` branch that shouldn't be compiled.