### PR TITLE
Fix the documentation link to point to `Perceptible` protocol inside `PerceptionCore`

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,4 +1,4 @@
 version: 1
 builder:
   configs:
-  - documentation_targets: [Perception, PerceptionCore]
+  - documentation_targets: [PerceptionCore, Perception]

--- a/README.md
+++ b/README.md
@@ -121,4 +121,4 @@ This library is released under the MIT license. See [LICENSE](LICENSE) for detai
 [pointfreeco]: https://www.pointfree.co
 [mbrandonw]: https://twitter.com/mbrandonw
 [stephencelis]: https://twitter.com/stephencelis
-[docs]: https://swiftpackageindex.com/pointfreeco/swift-perception/main/documentation/perceptioncore/perceptible
+[docs]: https://swiftpackageindex.com/pointfreeco/swift-perception/main/documentation/perception

--- a/README.md
+++ b/README.md
@@ -121,4 +121,4 @@ This library is released under the MIT license. See [LICENSE](LICENSE) for detai
 [pointfreeco]: https://www.pointfree.co
 [mbrandonw]: https://twitter.com/mbrandonw
 [stephencelis]: https://twitter.com/stephencelis
-[docs]: https://swiftpackageindex.com/pointfreeco/swift-perception/main/documentation/perception
+[docs]: https://swiftpackageindex.com/pointfreeco/swift-perception/main/documentation/perceptioncore/perceptible


### PR DESCRIPTION
The documentation link was originally pointing to the `Perception` module. However, it would be better if it were adjusted to point to `PerceptionCore`.