### PR TITLE
Avoid excessive view computation with `@Bindable`

### DIFF
--- a/Sources/PerceptionCore/Bindable.swift
+++ b/Sources/PerceptionCore/Bindable.swift
@@ -63,4 +63,10 @@
       self.object = object
     }
   }
+
+  extension Observer: Equatable where Object: AnyObject {
+    static func == (lhs: Observer, rhs: Observer) -> Bool {
+      lhs.object === rhs.object
+    }
+  }
 #endif


### PR DESCRIPTION
Because our `@Bindable` holds onto a reference, this reference is probed by SwiftUI to determine if a view body should be recomputed, and since the creation of the view is going to create a whole new reference, it is invalidating the view and causing it to re-render.

Instead, lets treat these references as equal if the objects they wrap are equal. This doesn't make things completely 1:1 with SwiftUI, as there is an initial invalidation in the parent, but a single extra invalidation seems like a good improvement.

Fixes #122.