### PR TITLE
Introduce `Bindable: Identifiable`

### DIFF
--- a/Sources/PerceptionCore/Bindable.swift
+++ b/Sources/PerceptionCore/Bindable.swift
@@ -54,6 +54,12 @@
     }
   }
 
+  extension Bindable: Identifiable where Value: Identifiable {
+    public var id: Value.ID {
+      wrappedValue.id
+    }
+  }
+
   @available(visionOS, unavailable)
   extension Bindable: Sendable where Value: Sendable {}
 


### PR DESCRIPTION
Matches the upstream conditional conformance in SwiftUI.