### PR TITLE
WithPerceptionTracking: Add support for custom DSL

### DIFF
--- a/Sources/PerceptionCore/WithPerceptionTracking.swift
+++ b/Sources/PerceptionCore/WithPerceptionTracking.swift
@@ -183,4 +183,26 @@
       }
     }
   #endif
+
+extension WithPerceptionTracking {
+  /// Constructs a `WithPerceptionTracking` with a custom `Content` builder.
+  ///
+  /// Only use this to enable support of external or custom domain-specific languages:
+  ///
+  /// ```swift
+  /// extension WithPerceptionTracking: MyCustomContent where Content: MyCustomContent
+  ///   init(@MyCustomContentBuilder content: @escaping () -> Content) {
+  ///     self = Self.make(customBuilder: content)
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// - Parameter customBuilder: Builds the `Content`
+  /// - Returns: A `WithPerceptionTracking<Content>`
+    public static func make(
+      customBuilder: @escaping () -> Content
+    ) -> WithPerceptionTracking<Content> {
+      Self.init(content: customBuilder)
+    }
+  }
 #endif

--- a/Sources/PerceptionCore/WithPerceptionTracking.swift
+++ b/Sources/PerceptionCore/WithPerceptionTracking.swift
@@ -77,6 +77,10 @@
       }
     }
 
+    public init(content: @escaping @autoclosure () -> Content) {
+      self.content = content
+    }
+
     @_transparent
     @inline(__always)
     private func instrumentedBody() -> Content {
@@ -183,26 +187,4 @@
       }
     }
   #endif
-
-  extension WithPerceptionTracking {
-    /// Constructs a `WithPerceptionTracking` with a custom `Content` builder.
-    ///
-    /// Only use this to enable support of external or custom domain-specific languages:
-    ///
-    /// ```swift
-    /// extension WithPerceptionTracking: MyCustomContent where Content: MyCustomContent
-    ///   init(@MyCustomContentBuilder content: @escaping () -> Content) {
-    ///     self = Self.make(customBuilder: content)
-    ///   }
-    /// }
-    /// ```
-    ///
-    /// - Parameter customBuilder: Builds the `Content`
-    /// - Returns: A `WithPerceptionTracking<Content>`
-    public static func make(
-      customBuilder: @escaping () -> Content
-    ) -> WithPerceptionTracking<Content> {
-      Self.init(content: customBuilder)
-    }
-  }
 #endif

--- a/Sources/PerceptionCore/WithPerceptionTracking.swift
+++ b/Sources/PerceptionCore/WithPerceptionTracking.swift
@@ -184,21 +184,21 @@
     }
   #endif
 
-extension WithPerceptionTracking {
-  /// Constructs a `WithPerceptionTracking` with a custom `Content` builder.
-  ///
-  /// Only use this to enable support of external or custom domain-specific languages:
-  ///
-  /// ```swift
-  /// extension WithPerceptionTracking: MyCustomContent where Content: MyCustomContent
-  ///   init(@MyCustomContentBuilder content: @escaping () -> Content) {
-  ///     self = Self.make(customBuilder: content)
-  ///   }
-  /// }
-  /// ```
-  ///
-  /// - Parameter customBuilder: Builds the `Content`
-  /// - Returns: A `WithPerceptionTracking<Content>`
+  extension WithPerceptionTracking {
+    /// Constructs a `WithPerceptionTracking` with a custom `Content` builder.
+    ///
+    /// Only use this to enable support of external or custom domain-specific languages:
+    ///
+    /// ```swift
+    /// extension WithPerceptionTracking: MyCustomContent where Content: MyCustomContent
+    ///   init(@MyCustomContentBuilder content: @escaping () -> Content) {
+    ///     self = Self.make(customBuilder: content)
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// - Parameter customBuilder: Builds the `Content`
+    /// - Returns: A `WithPerceptionTracking<Content>`
     public static func make(
       customBuilder: @escaping () -> Content
     ) -> WithPerceptionTracking<Content> {

--- a/Tests/PerceptionTests/WithPerceptionTrackingDSLTests.swift
+++ b/Tests/PerceptionTests/WithPerceptionTrackingDSLTests.swift
@@ -105,7 +105,7 @@ private struct CustomDSLContentBuilder {
 
 extension WithPerceptionTracking: CustomDSLContent where Content: CustomDSLContent {
   init(@CustomDSLContentBuilder content: @escaping () -> Content) {
-    self = Self.make(customBuilder: content)
+    self.init(content: content())
   }
 }
 

--- a/Tests/PerceptionTests/WithPerceptionTrackingDSLTests.swift
+++ b/Tests/PerceptionTests/WithPerceptionTrackingDSLTests.swift
@@ -1,30 +1,28 @@
 #if canImport(SwiftUI)
 import Perception
 import SwiftUI
-import Testing
+import XCTest
 
-struct WithPerceptionTrackingDSLTests {
-  @Test
+final class WithPerceptionTrackingDSLTests: XCTestCase {
+
   @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
-  func buildsAccessibilityRotorContent() {
+  func testBuildsAccessibilityRotorContent() {
     _ = WithPerceptionTracking {
       AccessibilityRotorEntry("foo", id: "bar")
     }
   }
 
-  @Test
   @available(iOS 14, macOS 11, *)
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
-  func buildsCommandContent() {
+  func testBuildsCommandContent() {
     _ = WithPerceptionTracking {
       EmptyCommands()
     }
   }
 
-  @Test
   @available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
-  func buildsCustomizableToolbarContent() {
+  func testBuildsCustomizableToolbarContent() {
     _ = WithPerceptionTracking {
       ToolbarItem {
         EmptyView()
@@ -32,9 +30,8 @@ struct WithPerceptionTrackingDSLTests {
     }
   }
 
-  @Test
   @available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
-  func buildsScene() {
+  func testBuildsScene() {
     _ = WithPerceptionTracking {
       WindowGroup {
         EmptyView()
@@ -42,29 +39,26 @@ struct WithPerceptionTrackingDSLTests {
     }
   }
 
-  @Test
   @available(iOS 16, macOS 12, *)
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
-  func buildsTableColumnContent() {
+  func testBuildsTableColumnContent() {
     _ = WithPerceptionTracking {
       TableColumn("Foo", value: \IdentifiableMock.id)
     }
   }
 
-  @Test
   @available(iOS 16, macOS 12, *)
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
-  func buildsTableRowContent() {
+  func testBuildsTableRowContent() {
     _ = WithPerceptionTracking {
       TableRow(IdentifiableMock(id: ""))
     }
   }
 
-  @Test
   @available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
-  func buildsToolbarContent() {
+  func testBuildsToolbarContent() {
     _ = WithPerceptionTracking {
       ToolbarItemGroup {
         EmptyView()
@@ -72,15 +66,13 @@ struct WithPerceptionTrackingDSLTests {
     }
   }
 
-  @Test
-  func buildsSwiftUIView() {
+  func testBuildsSwiftUIView() {
     _ = WithPerceptionTracking {
       EmptyView()
     }
   }
 
-  @Test
-  func buildsCustomDSL() {
+  func testBuildsCustomDSL() {
     _ = WithPerceptionTracking {
       CustomDSL()
     }

--- a/Tests/PerceptionTests/WithPerceptionTrackingDSLTests.swift
+++ b/Tests/PerceptionTests/WithPerceptionTrackingDSLTests.swift
@@ -1,0 +1,112 @@
+#if canImport(SwiftUI)
+import Perception
+import SwiftUI
+import Testing
+
+struct WithPerceptionTrackingDSLTests {
+  @Test
+  @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
+  func buildsAccessibilityRotorContent() {
+    _ = WithPerceptionTracking {
+      AccessibilityRotorEntry("foo", id: "bar")
+    }
+  }
+
+  @Test
+  @available(iOS 14, macOS 11, *)
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
+  func buildsCommandContent() {
+    _ = WithPerceptionTracking {
+      EmptyCommands()
+    }
+  }
+
+  @Test
+  @available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
+  func buildsCustomizableToolbarContent() {
+    _ = WithPerceptionTracking {
+      ToolbarItem {
+        EmptyView()
+      }
+    }
+  }
+
+  @Test
+  @available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
+  func buildsScene() {
+    _ = WithPerceptionTracking {
+      WindowGroup {
+        EmptyView()
+      }
+    }
+  }
+
+  @Test
+  @available(iOS 16, macOS 12, *)
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
+  func buildsTableColumnContent() {
+    _ = WithPerceptionTracking {
+      TableColumn("Foo", value: \IdentifiableMock.id)
+    }
+  }
+
+  @Test
+  @available(iOS 16, macOS 12, *)
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
+  func buildsTableRowContent() {
+    _ = WithPerceptionTracking {
+      TableRow(IdentifiableMock(id: ""))
+    }
+  }
+
+  @Test
+  @available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
+  func buildsToolbarContent() {
+    _ = WithPerceptionTracking {
+      ToolbarItemGroup {
+        EmptyView()
+      }
+    }
+  }
+
+  @Test
+  func buildsSwiftUIView() {
+    _ = WithPerceptionTracking {
+      EmptyView()
+    }
+  }
+
+  @Test
+  func buildsCustomDSL() {
+    _ = WithPerceptionTracking {
+      CustomDSL()
+    }
+  }
+
+}
+
+private struct IdentifiableMock: Identifiable {
+  var id: String
+}
+
+private protocol CustomDSLContent {}
+private struct CustomDSL: CustomDSLContent {}
+
+@resultBuilder
+private struct CustomDSLContentBuilder {
+    /// Builds an expression within the map content builder.
+    public static func buildBlock<Content>(_ content: Content) -> Content where Content: CustomDSLContent {
+        content
+    }
+}
+
+extension WithPerceptionTracking: CustomDSLContent where Content: CustomDSLContent {
+  init(@CustomDSLContentBuilder content: @escaping () -> Content) {
+    self = Self.make(customBuilder: content)
+  }
+}
+
+#endif


### PR DESCRIPTION
`WithPerceptionTracking` directly supports content for SwiftUI types (`View`, `Scene`, etc.). However, external frameworks or consuming applications may wish to construct their own DSL. It wouldn't be ideal for all of these use cases to leak into Perception itself, [as was the case for Charts](https://github.com/pointfreeco/swift-perception/pull/86). It's also likely that Apple will continue to release new `@resultBuilder` categories as iOS evolves, and consuming applications may wish to start with a `@retroactive` conformance before waiting for a library update & updating their dependency stack.

This adds a static factory that basically exposes the default initializer of `WithPerceptionTracking`. Since `init(content:)` is heavily overloaded, making the default initializer `public` could introduce ambiguity, and a specific signature adds intention around suggested usage. Open to alternative suggestions, though.

I've included some tests that are primarily for public interface stability. These use Swift Testing, but happy to change to XCTest if needed.