### PR TITLE
Support stable 6.1 in swift-syntax

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.1.0"),
-    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"601.0.0-prerelease"),
+    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"602.0.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.2.2"),
   ],
   targets: [


### PR DESCRIPTION
## WHY

- [Stable swift-syntax@6.1 is released.](https://github.com/swiftlang/swift-syntax/releases/tag/601.0.0)
- https://github.com/search?q=org%3Apointfreeco+swift-syntax+601+path%3A*.swift&type=code
