### PR TITLE
Store WithPerceptionTracking.Content in a enum 

### DIFF
--- a/Sources/PerceptionCore/WithPerceptionTracking.swift
+++ b/Sources/PerceptionCore/WithPerceptionTracking.swift
@@ -59,18 +59,41 @@
   @available(
     tvOS, deprecated: 17, message: "'WithPerceptionTracking' is no longer needed in tvOS 17+"
   )
+
+  enum _WithPerceptionTrackingContent<Content> {
+    case direct(Content)
+    case instrumented(() -> Content)
+    case tracked(() -> Content)
+
+    init(_ content: @escaping () -> Content) {
+      if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *), !isObservationBeta {
+        #if DEBUG
+        self = .instrumented(content)
+        #else
+        self = .direct(content())
+        #endif
+      } else {
+        self = .tracked(content)
+      }
+    }
+  }
+
   public struct WithPerceptionTracking<Content> {
     @State var id = 0
-    let content: () -> Content
+    let content: _WithPerceptionTrackingContent<Content>
 
     public var body: Content {
-      if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *), !isObservationBeta {
-        return self.instrumentedBody()
-      } else {
-        // NB: View will not re-render when 'id' changes unless we access it in the view.
+      switch content {
+      case .direct(let content):
+        return content
+        
+      case .instrumented(let content):
+        return instrumentedBody(content)
+        
+      case .tracked(let content):
         let _ = self.id
         return withPerceptionTracking {
-          self.instrumentedBody()
+          self.instrumentedBody(content)
         } onChange: { [_id = UncheckedSendable(self._id)] in
           _id.value.wrappedValue &+= 1
         }
@@ -78,18 +101,18 @@
     }
 
     public init(content: @escaping @autoclosure () -> Content) {
-      self.content = content
+      self.content = _WithPerceptionTrackingContent(content)
     }
 
     @_transparent
     @inline(__always)
-    private func instrumentedBody() -> Content {
+    private func instrumentedBody(_ content: () -> Content) -> Content {
       #if DEBUG
         return _PerceptionLocals.$isInPerceptionTracking.withValue(true) {
-          self.content()
+          content()
         }
       #else
-        return self.content()
+        return content()
       #endif
     }
   }
@@ -98,7 +121,7 @@
   extension WithPerceptionTracking: AccessibilityRotorContent
   where Content: AccessibilityRotorContent {
     public init(@AccessibilityRotorContentBuilder content: @escaping () -> Content) {
-      self.content = content
+      self.content = _WithPerceptionTrackingContent(content)
     }
   }
 
@@ -107,7 +130,7 @@
   @available(watchOS, unavailable)
   extension WithPerceptionTracking: Commands where Content: Commands {
     public init(@CommandsBuilder content: @escaping () -> Content) {
-      self.content = content
+      self.content = _WithPerceptionTrackingContent(content)
     }
   }
 
@@ -119,7 +142,7 @@
   @available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
   extension WithPerceptionTracking: Scene where Content: Scene {
     public init(@SceneBuilder content: @escaping () -> Content) {
-      self.content = content
+      self.content = _WithPerceptionTrackingContent(content)
     }
   }
 
@@ -133,7 +156,7 @@
 
     public init<R, C>(@TableColumnBuilder<R, C> content: @escaping () -> Content)
     where R == Content.TableRowValue, C == Content.TableColumnSortComparator {
-      self.content = content
+      self.content = _WithPerceptionTrackingContent(content)
     }
 
     nonisolated public var tableColumnBody: Never {
@@ -156,7 +179,7 @@
 
     public init<R>(@TableRowBuilder<R> content: @escaping () -> Content)
     where R == Content.TableRowValue {
-      self.content = content
+      self.content = _WithPerceptionTrackingContent(content)
     }
 
     nonisolated public var tableRowBody: Never {
@@ -167,13 +190,13 @@
   @available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
   extension WithPerceptionTracking: ToolbarContent where Content: ToolbarContent {
     public init(@ToolbarContentBuilder content: @escaping () -> Content) {
-      self.content = content
+      self.content = _WithPerceptionTrackingContent(content)
     }
   }
 
   extension WithPerceptionTracking: View where Content: View {
     public init(@ViewBuilder content: @escaping () -> Content) {
-      self.content = content
+      self.content = _WithPerceptionTrackingContent(content)
     }
   }
 
@@ -183,7 +206,7 @@
     @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
     extension WithPerceptionTracking: ChartContent where Content: ChartContent {
       public init(@ChartContentBuilder content: @escaping () -> Content) {
-        self.content = content
+        self.content = _WithPerceptionTrackingContent(content)
       }
     }
   #endif


### PR DESCRIPTION
### 🧠 Context

In SwiftUI, storing closures—especially escaping ones—can lead to unintended view recomputations. This occurs because SwiftUI may re-evaluate these closures even when the view’s state hasn’t changed, resulting in unnecessary performance overhead. By directly storing the evaluated content, we can prevent these redundant computations and enhance performance. ￼

---
###  ✅ Summary

- Introduced an internal enum _WithPerceptionTrackingContent to manage content storage strategies:
  - `.direct(Content)`: Stores the content directly, avoiding closure evaluation.
  - `.instrumented(() -> Content)`: Retains the closure for instrumentation in debug builds.
  - `.tracked(() -> Content)`: Maintains the closure for tracking in older OS versions or when necessary.
- On iOS 17+, in release builds and when not using Observation Beta, the content is stored directly, eliminating the need for closure evaluation.
- In debug builds or on older OS versions, the existing behavior with closures is preserved to maintain compatibility and debugging capabilities. ￼

---
### 🧪 Demo

A sample project is included to demonstrate the effectiveness of this change. It showcases how using an enum to store content directly prevents unnecessary body evaluations, leading to improved performance. 

<img  src="https://github.com/user-attachments/assets/625cb41e-c396-4d04-b954-7e0d24483bed" />

[ClosureExperiments.zip](https://github.com/user-attachments/files/19764441/ClosureExperiments.zip)
