### PR TITLE
Move internal type to fix documentation and deprecation

### DIFF
--- a/Sources/PerceptionCore/WithPerceptionTracking.swift
+++ b/Sources/PerceptionCore/WithPerceptionTracking.swift
@@ -63,25 +63,6 @@
   @available(
     tvOS, deprecated: 17, message: "'WithPerceptionTracking' is no longer needed in tvOS 17+"
   )
-
-  enum _WithPerceptionTrackingContent<Content> {
-    case direct(Content)
-    case instrumented(() -> Content)
-    case tracked(() -> Content)
-
-    init(_ content: @escaping () -> Content) {
-      if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *), !isObservationBeta {
-        #if DEBUG
-        self = .instrumented(content)
-        #else
-        self = .direct(content())
-        #endif
-      } else {
-        self = .tracked(content)
-      }
-    }
-  }
-
   public struct WithPerceptionTracking<Content> {
     @State var id = 0
     let content: _WithPerceptionTrackingContent<Content>
@@ -118,6 +99,24 @@
       #else
         return content()
       #endif
+    }
+  }
+
+  enum _WithPerceptionTrackingContent<Content> {
+    case direct(Content)
+    case instrumented(() -> Content)
+    case tracked(() -> Content)
+
+    init(_ content: @escaping () -> Content) {
+      if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *), !isObservationBeta {
+        #if DEBUG
+        self = .instrumented(content)
+        #else
+        self = .direct(content())
+        #endif
+      } else {
+        self = .tracked(content)
+      }
     }
   }
 


### PR DESCRIPTION
The documentation and deprecation on `WithPerceptionTracking` is broken as a result of #135. This is because the documentation is now attached to the internal enum type. 

Moving the `_WithPerceptionTrackingContent` type below `WithPerceptionTracking` so that the documentation is at the correct type.