### PR TITLE
Bump Perceptible and related types deprecation to *OS 26

### DIFF
--- a/Sources/Perception/Macros.swift
+++ b/Sources/Perception/Macros.swift
@@ -30,10 +30,10 @@
 ///            self.needsRepairs = needsRepairs
 ///        }
 ///     }
-@available(iOS, deprecated: 17, renamed: "Observable")
-@available(macOS, deprecated: 14, renamed: "Observable")
-@available(watchOS, deprecated: 10, renamed: "Observable")
-@available(tvOS, deprecated: 17, renamed: "Observable")
+@available(iOS, deprecated: 26, renamed: "Observable")
+@available(macOS, deprecated: 26, renamed: "Observable")
+@available(watchOS, deprecated: 26, renamed: "Observable")
+@available(tvOS, deprecated: 26, renamed: "Observable")
 @attached(member, names: named(_$perceptionRegistrar), named(access), named(withMutation), named(shouldNotifyObservers))
 @attached(memberAttribute)
 @attached(extension, conformances: Perceptible, Observable)
@@ -46,10 +46,10 @@ public macro Perceptible() =
 ///
 /// The ``Perception`` module uses this macro. Its use outside of the
 /// framework isn't necessary.
-@available(iOS, deprecated: 17, renamed: "ObservationTracked")
-@available(macOS, deprecated: 14, renamed: "ObservationTracked")
-@available(watchOS, deprecated: 10, renamed: "ObservationTracked")
-@available(tvOS, deprecated: 17, renamed: "ObservationTracked")
+@available(iOS, deprecated: 26, renamed: "ObservationTracked")
+@available(macOS, deprecated: 26, renamed: "ObservationTracked")
+@available(watchOS, deprecated: 26, renamed: "ObservationTracked")
+@available(tvOS, deprecated: 26, renamed: "ObservationTracked")
 @attached(accessor, names: named(init), named(get), named(set), named(_modify))
 @attached(peer, names: prefixed(_))
 public macro PerceptionTracked() =
@@ -62,10 +62,10 @@ public macro PerceptionTracked() =
 /// By default, an object can perceive any property of a perceptible type that
 /// is accessible to the perceiving object. To prevent perception of an
 /// accessible property, attach the `PerceptionIgnored` macro to the property.
-@available(iOS, deprecated: 17, renamed: "ObservationIgnored")
-@available(macOS, deprecated: 14, renamed: "ObservationIgnored")
-@available(watchOS, deprecated: 10, renamed: "ObservationIgnored")
-@available(tvOS, deprecated: 17, renamed: "ObservationIgnored")
+@available(iOS, deprecated: 26, renamed: "ObservationIgnored")
+@available(macOS, deprecated: 26, renamed: "ObservationIgnored")
+@available(watchOS, deprecated: 26, renamed: "ObservationIgnored")
+@available(tvOS, deprecated: 26, renamed: "ObservationIgnored")
 @attached(accessor, names: named(willSet))
 public macro PerceptionIgnored() =
   #externalMacro(module: "PerceptionMacros", type: "PerceptionIgnoredMacro")

--- a/Sources/PerceptionCore/Perceptible.swift
+++ b/Sources/PerceptionCore/Perceptible.swift
@@ -19,8 +19,8 @@
 /// type doesn't add perception functionality to the type. Instead, always use
 /// the ``Perception/Perceptible()`` macro when adding perception
 /// support to a type.
-@available(iOS, deprecated: 17, renamed: "Observable")
-@available(macOS, deprecated: 14, renamed: "Observable")
-@available(watchOS, deprecated: 10, renamed: "Observable")
-@available(tvOS, deprecated: 17, renamed: "Observable")
+@available(iOS, deprecated: 26, renamed: "Observable")
+@available(macOS, deprecated: 26, renamed: "Observable")
+@available(watchOS, deprecated: 26, renamed: "Observable")
+@available(tvOS, deprecated: 26, renamed: "Observable")
 public protocol Perceptible { }

--- a/Sources/PerceptionCore/Perception/PerceptionRegistrar.swift
+++ b/Sources/PerceptionCore/Perception/PerceptionRegistrar.swift
@@ -8,10 +8,10 @@ import IssueReporting
 ///
 /// You don't need to create an instance of `PerceptionRegistrar` when using
 /// the ``Perception/Perceptible()`` macro to indicate perceptibility of a type.
-@available(iOS, deprecated: 17, renamed: "ObservationRegistrar")
-@available(macOS, deprecated: 14, renamed: "ObservationRegistrar")
-@available(watchOS, deprecated: 10, renamed: "ObservationRegistrar")
-@available(tvOS, deprecated: 17, renamed: "ObservationRegistrar")
+@available(iOS, deprecated: 26, renamed: "ObservationRegistrar")
+@available(macOS, deprecated: 26, renamed: "ObservationRegistrar")
+@available(watchOS, deprecated: 26, renamed: "ObservationRegistrar")
+@available(tvOS, deprecated: 26, renamed: "ObservationRegistrar")
 public struct PerceptionRegistrar: Sendable {
   private let rawValue: any Sendable
   #if DEBUG

--- a/Sources/PerceptionCore/_PerceptionRegistrar.swift
+++ b/Sources/PerceptionCore/_PerceptionRegistrar.swift
@@ -9,10 +9,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-@available(iOS, deprecated: 17, renamed: "ObservationRegistrar")
-@available(macOS, deprecated: 14, renamed: "ObservationRegistrar")
-@available(watchOS, deprecated: 10, renamed: "ObservationRegistrar")
-@available(tvOS, deprecated: 17, renamed: "ObservationRegistrar")
+@available(iOS, deprecated: 26, renamed: "ObservationRegistrar")
+@available(macOS, deprecated: 26, renamed: "ObservationRegistrar")
+@available(watchOS, deprecated: 26, renamed: "ObservationRegistrar")
+@available(tvOS, deprecated: 26, renamed: "ObservationRegistrar")
 @usableFromInline
 internal struct _PerceptionRegistrar: Sendable {
   internal class ValuePerceptionStorage {


### PR DESCRIPTION
This changes `Perceptible` deprecation to OS 26, keeping `withPerceptibleTracking` as-is at iOS 17/macOS 14 

This makes it cleaner to use the library specifically for its backport of `shouldNotifyObservers` such as to avoid over-observation in cases such as the following:

```swift
import Perception
import SwiftUI

@Perceptible
final class Model {
  var flag: Bool = false
}

struct ContentView: View {
  let model = Model()
  var body: some View {
    let _ = print("body")
    Button(model.flag ? "On" : "Off") {
      model.flag = model.flag
    }
  }
}
```


Compiling for macOS 15 now reports the following deprecations in the test suite:

<img width="701" height="340" alt="image" src="https://github.com/user-attachments/assets/d7efc7b3-01f4-4c7a-a836-cc65624f1756" />