### PR TITLE
feat: Add KeyPath-specific observation to withPerceptionTracking

### DIFF
--- a/Tests/PerceptionTests/PerceptionTrackingTests.swift
+++ b/Tests/PerceptionTests/PerceptionTrackingTests.swift
@@ -38,6 +38,31 @@ final class PerceptionTrackingTests: XCTestCase {
     XCTAssertEqual(model.count2, 1)
     isComplete = true
   }
+
+  func testMutateSpecificAccessedField() {
+    let model = Model()
+
+    let expectation = self.expectation(description: "count1 changed")
+    withPerceptionTracking {
+      _ = model.count1
+      _ = model.count2
+    } for: \.count1 onChange: { [weak self] in
+      guard let self else { return }
+      if !self.isComplete {
+        expectation.fulfill()
+      }
+    }
+    model.count2 += 1
+    XCTAssertEqual(model.count1, 0)
+    XCTAssertEqual(model.count2, 1)
+    self.wait(for: [expectation], timeout: 0.001) // Should not fulfill
+
+    model.count1 += 1
+    XCTAssertEqual(model.count1, 1)
+    XCTAssertEqual(model.count2, 1)
+    self.wait(for: [expectation], timeout: 0)
+    isComplete = true
+  }
 }
 
 @Perceptible


### PR DESCRIPTION

**Add KeyPath-specific overload to `withPerceptionTracking`**

This PR introduces a new overload of `withPerceptionTracking` that lets developers observe changes to a specific `KeyPath` of a `Perceptible` object.

**Why it matters:**
The existing tracking triggers on any property change, but many apps only need to react to particular properties. This addition enables more precise observation, improving performance by avoiding unnecessary updates and giving finer control over callbacks.

**Key points:**

* New public `withPerceptionTracking` overload accepting a `KeyPath`
* Filters change notifications using the specified `KeyPath` via `_installTracking`
* Adds a test case (`testMutateSpecificAccessedField`) validating this behavior

This enhancement provides a more efficient, targeted observation pattern, extending swift-perception’s capabilities to support advanced reactive systems.

