### PR TITLE
Remove WithPerceptionTracking's MapKit support

### DIFF
--- a/Sources/PerceptionCore/SwiftUI/WithPerceptionTracking.swift
+++ b/Sources/PerceptionCore/SwiftUI/WithPerceptionTracking.swift
@@ -219,15 +219,4 @@
       }
     }
   #endif
-
-  #if canImport(MapKit)
-    import MapKit
-
-    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-    extension WithPerceptionTracking: MapContent where Content: MapContent {
-      public init(@MapContentBuilder content: @escaping () -> Content) {
-        self.init(content: content())
-      }
-    }
-  #endif
 #endif


### PR DESCRIPTION
This was added in #134 but given the availability matches the availability of Observation, it shouldn't be necessary.

It also seems to introduce problems with some build systems, like Skip.