### PR TITLE
fix: add deprecated overload for Observable based access

### DIFF
--- a/Sources/PerceptionCore/Internal/Deprecations.swift
+++ b/Sources/PerceptionCore/Internal/Deprecations.swift
@@ -3,6 +3,7 @@ extension PerceptionRegistrar {
   @available(macOS, deprecated: 9999, renamed: "access(_:keyPath:)")
   @available(tvOS, deprecated: 9999, renamed: "access(_:keyPath:)")
   @available(watchOS, deprecated: 9999, renamed: "access(_:keyPath:)")
+  @_disfavoredOverload
   public func access<Subject: Perceptible, Member>(
     _ subject: Subject,
     keyPath: KeyPath<Subject, Member>,
@@ -14,3 +15,23 @@ extension PerceptionRegistrar {
     access(subject, keyPath: keyPath)
   }
 }
+
+#if canImport(Observation)
+@available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+extension PerceptionRegistrar {
+  @available(iOS, deprecated: 9999, renamed: "access(_:keyPath:)")
+  @available(macOS, deprecated: 9999, renamed: "access(_:keyPath:)")
+  @available(tvOS, deprecated: 9999, renamed: "access(_:keyPath:)")
+  @available(watchOS, deprecated: 9999, renamed: "access(_:keyPath:)")
+  public func access<Subject: Observable, Member>(
+    _ subject: Subject,
+    keyPath: KeyPath<Subject, Member>,
+    fileID: StaticString,
+    filePath: StaticString,
+    line: UInt,
+    column: UInt
+  ) {
+    access(subject, keyPath: keyPath)
+  }
+}
+#endif


### PR DESCRIPTION
Currently if you call the perception registrar with a subject that is both `Perceptible` and `Observable` it will call the `Observable` variants since the `Perceptible` implementations are disfavored.

The exception is if your subject still calls the deprecated variant of the access function, in this case the `Perceptible` variant will be called possibly leading to an erroneous perception runtime warning.

Adding a `Observable` based implementation of the deprecated function reroutes the call to the non deprecated `Observable` implementation properly.

I am not sure whether you want to integrate this since it practically adds a deprecated function and it can also be fixed on the user side by moving to the non-deprecated function. But the perception warning lead to some confusion in our project.