### PR TITLE
Fix Bindable compilation on Xcode 26+ / iOS 17+

### DIFF
--- a/Sources/PerceptionCore/SwiftUI/Bindable.swift
+++ b/Sources/PerceptionCore/SwiftUI/Bindable.swift
@@ -1,126 +1,135 @@
-#if canImport(SwiftUI)
-  import SwiftUI
+// NB: This file is excluded from compilation on iOS 17+, macOS 14+, tvOS 17+, watchOS 10+,
+// and visionOS where native @Bindable is available. Xcode 26+ treats @available(obsoleted:)
+// as a compile-time error for extensions on unavailable types.
+#if !os(visionOS)
+  #if (os(iOS) && swift(<5.9)) || (os(macOS) && swift(<5.9)) || (os(tvOS) && swift(<5.9)) || (os(watchOS) && swift(<5.9)) || (!os(iOS) && !os(macOS) && !os(tvOS) && !os(watchOS))
 
-  /// A property wrapper type that supports creating bindings to the mutable properties of
-  /// perceptible objects.
-  ///
-  /// > Important: This is a back-port of SwiftUI's `Bindable` property wrapper.
-  @available(
-    iOS,
-    introduced: 13,
-    obsoleted: 17,
-    message: "Use @Bindable without the 'Perception.' prefix."
-  )
-  @available(
-    macOS,
-    introduced: 10.15,
-    obsoleted: 14,
-    message: "Use @Bindable without the 'Perception.' prefix."
-  )
-  @available(
-    tvOS,
-    introduced: 13,
-    obsoleted: 17,
-    message: "Use @Bindable without the 'Perception.' prefix."
-  )
-  @available(
-    watchOS,
-    introduced: 6,
-    obsoleted: 10,
-    message: "Use @Bindable without the 'Perception.' prefix."
-  )
-  @available(visionOS, unavailable)
-  @dynamicMemberLookup
-  @propertyWrapper
-  public struct Bindable<Value> {
-    @ObservedObject fileprivate var observer: Observer<Value>
+    #if canImport(SwiftUI)
+      import SwiftUI
 
-    /// The wrapped object.
-    public var wrappedValue: Value {
-      get { observer.object }
-      set { observer.object = newValue }
-    }
+      /// A property wrapper type that supports creating bindings to the mutable properties of
+      /// perceptible objects.
+      ///
+      /// > Important: This is a back-port of SwiftUI's `Bindable` property wrapper.
+      @available(
+        iOS,
+        introduced: 13,
+        obsoleted: 17,
+        message: "Use @Bindable without the 'Perception.' prefix."
+      )
+      @available(
+        macOS,
+        introduced: 10.15,
+        obsoleted: 14,
+        message: "Use @Bindable without the 'Perception.' prefix."
+      )
+      @available(
+        tvOS,
+        introduced: 13,
+        obsoleted: 17,
+        message: "Use @Bindable without the 'Perception.' prefix."
+      )
+      @available(
+        watchOS,
+        introduced: 6,
+        obsoleted: 10,
+        message: "Use @Bindable without the 'Perception.' prefix."
+      )
+      @available(visionOS, unavailable)
+      @dynamicMemberLookup
+      @propertyWrapper
+      public struct Bindable<Value> {
+        @ObservedObject fileprivate var observer: Observer<Value>
 
-    /// The bindable wrapper for the object that creates bindings to its properties using dynamic
-    /// member lookup.
-    public var projectedValue: Bindable<Value> {
-      self
-    }
-
-    /// Returns a binding to the value of a given key path.
-    public subscript<Subject>(
-      dynamicMember keyPath: ReferenceWritableKeyPath<Value, Subject>
-    ) -> Binding<Subject> where Value: AnyObject {
-      #if DEBUG && canImport(SwiftUI)
-        func open<V: Perceptible>(_: V.Type) -> Binding<Subject> {
-          ($observer as! ObservedObject<Observer<V>>.Wrapper).object[
-            isPerceptionTracking: _PerceptionLocals.isInPerceptionTracking,
-            keyPath: unsafeDowncast(keyPath, to: ReferenceWritableKeyPath<V, Subject>.self)
-          ]
+        /// The wrapped object.
+        public var wrappedValue: Value {
+          get { observer.object }
+          set { observer.object = newValue }
         }
-        guard let valueType = Value.self as? any Perceptible.Type else { fatalError() }
-        return open(valueType)
-      #else
-        $observer.object[dynamicMember: keyPath]
-      #endif
-    }
 
-    /// Creates a bindable object from an observable object.
-    public init(wrappedValue: Value) where Value: AnyObject & Perceptible {
-      self.observer = Observer(wrappedValue)
-    }
-
-    /// Creates a bindable object from an observable object.
-    public init(_ wrappedValue: Value) where Value: AnyObject & Perceptible {
-      self.init(wrappedValue: wrappedValue)
-    }
-
-    /// Creates a bindable from the value of another bindable.
-    public init(projectedValue: Bindable<Value>) where Value: AnyObject & Perceptible {
-      self = projectedValue
-    }
-  }
-
-  @available(visionOS, unavailable)
-  extension Bindable: Identifiable where Value: Identifiable {
-    public var id: Value.ID {
-      wrappedValue.id
-    }
-  }
-
-  @available(visionOS, unavailable)
-  extension Bindable: Sendable where Value: Sendable {}
-
-  private final class Observer<Object>: ObservableObject {
-    var object: Object
-    init(_ object: Object) {
-      self.object = object
-    }
-  }
-
-  extension Observer: Equatable where Object: AnyObject {
-    static func == (lhs: Observer, rhs: Observer) -> Bool {
-      lhs.object === rhs.object
-    }
-  }
-
-  #if DEBUG
-    extension Perceptible {
-      fileprivate subscript<Member>(
-        isPerceptionTracking isPerceptionTracking: Bool,
-        keyPath keyPath: ReferenceWritableKeyPath<Self, Member>
-      ) -> Member {
-        get {
-          _PerceptionLocals.$isInPerceptionTracking.withValue(isPerceptionTracking) {
-            self[keyPath: keyPath]
-          }
+        /// The bindable wrapper for the object that creates bindings to its properties using dynamic
+        /// member lookup.
+        public var projectedValue: Bindable<Value> {
+          self
         }
-        set {
-          _PerceptionLocals.$isInPerceptionTracking.withValue(isPerceptionTracking) {
-            self[keyPath: keyPath] = newValue
-          }
+
+        /// Returns a binding to the value of a given key path.
+        public subscript<Subject>(
+          dynamicMember keyPath: ReferenceWritableKeyPath<Value, Subject>
+        ) -> Binding<Subject> where Value: AnyObject {
+          #if DEBUG && canImport(SwiftUI)
+            func open<V: Perceptible>(_: V.Type) -> Binding<Subject> {
+              ($observer as! ObservedObject<Observer<V>>.Wrapper).object[
+                isPerceptionTracking: _PerceptionLocals.isInPerceptionTracking,
+                keyPath: unsafeDowncast(keyPath, to: ReferenceWritableKeyPath<V, Subject>.self)
+              ]
+            }
+            guard let valueType = Value.self as? any Perceptible.Type else { fatalError() }
+            return open(valueType)
+          #else
+            $observer.object[dynamicMember: keyPath]
+          #endif
+        }
+
+        /// Creates a bindable object from an observable object.
+        public init(wrappedValue: Value) where Value: AnyObject & Perceptible {
+          self.observer = Observer(wrappedValue)
+        }
+
+        /// Creates a bindable object from an observable object.
+        public init(_ wrappedValue: Value) where Value: AnyObject & Perceptible {
+          self.init(wrappedValue: wrappedValue)
+        }
+
+        /// Creates a bindable from the value of another bindable.
+        public init(projectedValue: Bindable<Value>) where Value: AnyObject & Perceptible {
+          self = projectedValue
         }
       }
-    }
+
+      @available(visionOS, unavailable)
+      extension Bindable: Identifiable where Value: Identifiable {
+        public var id: Value.ID {
+          wrappedValue.id
+        }
+      }
+
+      @available(visionOS, unavailable)
+      extension Bindable: Sendable where Value: Sendable {}
+
+      private final class Observer<Object>: ObservableObject {
+        var object: Object
+        init(_ object: Object) {
+          self.object = object
+        }
+      }
+
+      extension Observer: Equatable where Object: AnyObject {
+        static func == (lhs: Observer, rhs: Observer) -> Bool {
+          lhs.object === rhs.object
+        }
+      }
+
+      #if DEBUG
+        extension Perceptible {
+          fileprivate subscript<Member>(
+            isPerceptionTracking isPerceptionTracking: Bool,
+            keyPath keyPath: ReferenceWritableKeyPath<Self, Member>
+          ) -> Member {
+            get {
+              _PerceptionLocals.$isInPerceptionTracking.withValue(isPerceptionTracking) {
+                self[keyPath: keyPath]
+              }
+            }
+            set {
+              _PerceptionLocals.$isInPerceptionTracking.withValue(isPerceptionTracking) {
+                self[keyPath: keyPath] = newValue
+              }
+            }
+          }
+        }
+      #endif
+    #endif
+
   #endif
 #endif


### PR DESCRIPTION
## Summary

Xcode 26 treats `@available(obsoleted:)` as a compile-time error when extensions are declared on unavailable types. This causes `Bindable.swift` to fail compilation on iOS 17+, macOS 14+, tvOS 17+, watchOS 10+.

## Error

```
error: 'Bindable' is unavailable in iOS: Use @Bindable without the 'Perception.' prefix.
extension Bindable: Identifiable where Value: Identifiable {
```

## Fix

This wraps the entire file in `#if` guards to exclude it from compilation when native `@Bindable` is available (Swift 5.9+ on Apple platforms).

## Checklist

- [x] I have determined that this bug is not reproducible using Swift's observation tools
- [x] I've reproduced the issue using the main branch of this package
- [x] This issue hasn't been addressed in an existing GitHub issue or discussion