### PR TITLE
Fix documentation link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,7 +5,7 @@ contact_links:
     url: https://github.com/pointfreeco/swift-perception/discussions
     about: Perception Q&A, ideas, and more
   - name: Documentation
-    url: https://pointfreeco.github.io/swift-perception/main/documentation/perception/
+    url: https://swiftpackageindex.com/pointfreeco/swift-perception/main/documentation/perception
     about: Read Perception's documentation
   - name: Videos
     url: https://www.pointfree.co/


### PR DESCRIPTION
Updates the issue template documentation contact link to the Swift Package Index DocC URL.