### PR TITLE
Disfavor the base WithPerceptionTracking initializer to fix ambiguity on the Swift 6.4 snapshot

### DIFF
--- a/Sources/PerceptionCore/SwiftUI/WithPerceptionTracking.swift
+++ b/Sources/PerceptionCore/SwiftUI/WithPerceptionTracking.swift
@@ -109,6 +109,7 @@
       }
     }
 
+    @_disfavoredOverload
     public init(content: @escaping @autoclosure () -> Content) {
       self.content = _Content(content)
     }

--- a/Tests/PerceptionTests/WithPerceptionTrackingOverloadTests.swift
+++ b/Tests/PerceptionTests/WithPerceptionTrackingOverloadTests.swift
@@ -2,9 +2,7 @@
   import Perception
   import SwiftUI
 
-  // Compile-time test for https://github.com/swiftlang/swift/issues/90628:
-  // this file fails to build on the Xcode 27 beta toolchain without
-  // '@_disfavoredOverload' on the base 'WithPerceptionTracking' initializer.
+  // https://github.com/swiftlang/swift/issues/90628
   @MainActor
   private protocol Coordinator: AnyObject {
     associatedtype Root: View
@@ -14,7 +12,6 @@
   @Perceptible
   private final class FeatureCoordinator: Coordinator {
     var count = 0
-
     func buildRoot() -> some View {
       WithPerceptionTracking { [self] in
         Text("\(count)")

--- a/Tests/PerceptionTests/WithPerceptionTrackingOverloadTests.swift
+++ b/Tests/PerceptionTests/WithPerceptionTrackingOverloadTests.swift
@@ -1,0 +1,24 @@
+#if canImport(SwiftUI)
+  import Perception
+  import SwiftUI
+
+  // Compile-time test for https://github.com/swiftlang/swift/issues/90628:
+  // this file fails to build on the Xcode 27 beta toolchain without
+  // '@_disfavoredOverload' on the base 'WithPerceptionTracking' initializer.
+  @MainActor
+  private protocol Coordinator: AnyObject {
+    associatedtype Root: View
+    @ViewBuilder func buildRoot() -> Root
+  }
+
+  @Perceptible
+  private final class FeatureCoordinator: Coordinator {
+    var count = 0
+
+    func buildRoot() -> some View {
+      WithPerceptionTracking { [self] in
+        Text("\(count)")
+      }
+    }
+  }
+#endif


### PR DESCRIPTION
On the Xcode 27 beta toolchain a trailing closure with a capture list produces "ambiguous use of 'init(content:)'" between the base `@autoclosure` initializer and the `ViewBuilder` one (swiftlang/swift#90628). Mark the base initializer `@_disfavoredOverload`, mirroring the `ChartContent` workaround from 2.0.4. Adds a compile-time test with the shape from the report.

Prepared with AI assistance; changes verified by hand.
