### PR TITLE
Fix transitive dependency linking problem with IssueReporting

### DIFF
--- a/Sources/PerceptionCore/Perception/PerceptionRegistrar.swift
+++ b/Sources/PerceptionCore/Perception/PerceptionRegistrar.swift
@@ -1,5 +1,3 @@
-public import IssueReporting
-
 #if canImport(Observation)
   public import Observation
 #endif
@@ -7,6 +5,7 @@ public import IssueReporting
   import SwiftUI
 #endif
 #if DEBUG && canImport(SwiftUI)
+  import IssueReporting
   import MachO
 #endif
 
@@ -254,7 +253,6 @@ extension PerceptionRegistrar: Hashable {
 
 #if DEBUG && canImport(SwiftUI)
   extension PerceptionRegistrar {
-    @_transparent
     @usableFromInline
     func check<Subject, Member>(_ keyPath: KeyPath<Subject, Member>) {
       if _isPerceptionCheckingEnabled,


### PR DESCRIPTION
Hi,

I noticed that when importing swift-perception (tested on latest release 2.0.11), I would get a linking errors related to IssueReporting on debug testing builds:
`Undefined symbols for architecture arm64:
IssueReporting._recordIssue(message: Swift.String?, ...`

Now I guess a workaround is possible here by importing the IssueReporting package as well, but since I have no direct use for this, this seems cumbersome to maintain.

I know the public import of IssueReporting is required because of the @_transparent macro, but I am not aware what implications are by removing this.

Feel free to decline this PR if there is a better solution for this, happy to learn here!